### PR TITLE
[Fix] - Add OpenSSL to Dockerfile for Prisma compatibility

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,7 +33,7 @@ RUN cp swagger.json dist/
 FROM node:18-alpine AS production
 
 # Instalar dependências de runtime
-RUN apk add --no-cache dumb-init
+RUN apk add --no-cache dumb-init openssl
 
 # Criar usuário não-root para segurança
 RUN addgroup -g 1001 -S nodejs


### PR DESCRIPTION
Adiciona openssl no stage de produção do Dockerfile para resolver erro do Prisma Engine no Alpine Linux.