### PR TITLE
[Fix] - Update script paths after reorganization

### DIFF
--- a/.github/workflows/backup.yml
+++ b/.github/workflows/backup.yml
@@ -32,7 +32,7 @@ jobs:
           VPS_HOST: ${{ secrets.VPS_HOST }}
           ENVIRONMENT: ${{ github.event.inputs.environment || 'dev' }}
         run: |
-          BACKUP_OUTPUT=$(ssh -i ~/.ssh/id_rsa ${VPS_USER}@${VPS_HOST} "bash -l -c 'cd ~/gas-e-agua-backend && bash ./scripts/backup-db.sh ${ENVIRONMENT}'")
+          BACKUP_OUTPUT=$(ssh -i ~/.ssh/id_rsa ${VPS_USER}@${VPS_HOST} "bash -l -c 'cd ~/gas-e-agua-backend && bash ./scripts/deploy/backup-db.sh ${ENVIRONMENT}'")
 
           echo "$BACKUP_OUTPUT"
 

--- a/scripts/deploy/notify.sh
+++ b/scripts/deploy/notify.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Script de notificação de deploy
-# Uso: ./scripts/notify.sh [success|failure] [env] [message]
+# Uso: ./scripts/deploy/notify.sh [success|failure] [env] [message]
 
 set -e
 


### PR DESCRIPTION
## 🐛 Problema

Após a reorganização dos scripts (#46), alguns caminhos antigos ainda estavam sendo referenciados, causando erro:
```
bash: line 1: ./scripts/backup-db.sh: No such file or directory
```

## 🔧 Correções

- ✅ `.github/actions/backup/action.yml` - `scripts/backup-db.sh` → `scripts/deploy/backup-db.sh`
- ✅ `.github/workflows/backup.yml` - `scripts/backup-db.sh` → `scripts/deploy/backup-db.sh`  
- ✅ `scripts/deploy/notify.sh` - Atualizado comentário de uso

## 🔗 Relacionado

- Depende de #46 (reorganização de scripts)
- Fix para erro de backup workflow