### PR TITLE
fix: Corrige formato do nome do repositório no GHCR

### DIFF
--- a/.github/workflows/test-ghcr.yml
+++ b/.github/workflows/test-ghcr.yml
@@ -29,8 +29,9 @@ jobs:
           # Pull a small test image
           docker pull hello-world
 
-          # Tag it with your repository
-          IMAGE_NAME="ghcr.io/${{ github.repository_owner }}/gas-e-agua-backend-test"
+          # Tag it with your repository (lowercase required by GHCR)
+          REPO_OWNER=$(echo "${{ github.repository_owner }}" | tr '[:upper:]' '[:lower:]')
+          IMAGE_NAME="ghcr.io/${REPO_OWNER}/gas-e-agua-backend-test"
           docker tag hello-world $IMAGE_NAME:test
 
           # Push to GHCR


### PR DESCRIPTION
## 🐛 Fix: Nome do repositório em lowercase para GHCR

### Problema
O workflow de teste do GHCR estava falhando com erro:
```
invalid reference format: repository name must be lowercase
```

### Solução
- Adiciona conversão automática do `repository_owner` para lowercase usando `tr`
- GHCR exige nomes de repositório em minúsculas

### Mudanças
- Atualiza `.github/workflows/test-ghcr.yml`
- Converte `LucasEmanuel9611` → `lucasemanuel9611`

Fixes o erro de push para GHCR.