### PR TITLE
feat: implementar gestão granular de endereços

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -30,8 +30,8 @@ npm install
 cp env.app.dev.example .env.dev
 nano .env.dev  # Editar com suas credenciais locais
 
-# 4. Subir containers (MySQL, Redis)
-docker compose -p gas-e-agua-dev -f docker-compose.dev.yml up -d
+# 4. Subir apenas banco de dados e Redis (para desenvolvimento local)
+docker compose -p gas-e-agua-dev -f docker-compose.dev.yml up -d mysql redis
 
 # 5. Rodar migrations
 npx prisma migrate dev
@@ -325,18 +325,39 @@ npx prisma migrate reset
 
 ### Docker
 
-```bash
-# Subir todos os serviços
-docker compose -p gas-e-agua-dev -f docker-compose.dev.yml up -d
+> **💡 Dica:** Para desenvolvimento com hot reload, use a **Opção 1**. Para testar o ambiente completo, use a **Opção 2**.
 
-# Ver logs
-docker compose -p gas-e-agua-dev -f docker-compose.dev.yml logs -f app
+#### Opção 1: Desenvolvimento Local (Recomendado)
+```bash
+# Subir apenas banco de dados e Redis (API roda localmente com npm run dev)
+docker compose -p gas-e-agua-dev -f docker-compose.dev.yml up -d mysql redis
+
+# Ver logs do banco
+docker compose -p gas-e-agua-dev -f docker-compose.dev.yml logs -f mysql
 
 # Parar serviços
 docker compose -p gas-e-agua-dev -f docker-compose.dev.yml down
+```
 
+#### Opção 2: Tudo em Container (Para testes)
+```bash
+# Subir todos os serviços (API também em container)
+docker compose -p gas-e-agua-dev -f docker-compose.dev.yml up -d
+
+# Ver logs da API
+docker compose -p gas-e-agua-dev -f docker-compose.dev.yml logs -f app
+
+# Parar todos os serviços
+docker compose -p gas-e-agua-dev -f docker-compose.dev.yml down
+```
+
+#### Comandos Úteis
+```bash
 # Remover volumes (CUIDADO - apaga dados!)
 docker compose -p gas-e-agua-dev -f docker-compose.dev.yml down -v
+
+# Rebuild da imagem da API
+docker compose -p gas-e-agua-dev -f docker-compose.dev.yml build app
 ```
 
 ## 📂 Estrutura de Scripts

--- a/README.md
+++ b/README.md
@@ -107,8 +107,8 @@ npm install
 cp env.app.dev.example .env.dev
 nano .env.dev  # Editar credenciais
 
-# 4. Subir containers
-docker compose -p gas-e-agua-dev -f docker-compose.dev.yml up -d
+# 4. Subir banco de dados e Redis
+docker compose -p gas-e-agua-dev -f docker-compose.dev.yml up -d mysql redis
 
 # 5. Aplicar migrations e seeds
 npx prisma migrate deploy
@@ -236,7 +236,11 @@ npx prisma db seed               # Executar seeds
 
 ### Docker
 ```bash
-# DEV
+# DEV (apenas banco + Redis para desenvolvimento local)
+docker compose -p gas-e-agua-dev -f docker-compose.dev.yml up -d mysql redis
+docker compose -p gas-e-agua-dev -f docker-compose.dev.yml logs -f mysql
+
+# DEV (tudo em container - para testes)
 docker compose -p gas-e-agua-dev -f docker-compose.dev.yml up -d
 docker compose -p gas-e-agua-dev -f docker-compose.dev.yml logs -f app
 

--- a/src/modules/accounts/repositories/interfaces/IUserRepository.ts
+++ b/src/modules/accounts/repositories/interfaces/IUserRepository.ts
@@ -6,6 +6,7 @@ export interface IUsersRepository {
   findById(id: number): Promise<UserDates>;
   findAdmin(): Promise<UserDates>;
   update(data: IUpdateUserDTO): Promise<UserDates>;
+  deleteAddress(userId: number, addressId: number): Promise<void>;
   findAll(data: {
     page: number;
     limit: number;

--- a/src/modules/accounts/repositories/interfaces/IUserRepository.ts
+++ b/src/modules/accounts/repositories/interfaces/IUserRepository.ts
@@ -1,4 +1,11 @@
-import { ICreateUserDTO, IUpdateUserDTO, UserDates } from "../../types";
+import {
+  AddressDates,
+  ICreateAddressRequestDTO,
+  ICreateUserDTO,
+  IUpdateAddressRequestDTO,
+  IUpdateUserDTO,
+  UserDates,
+} from "../../types";
 
 export interface IUsersRepository {
   create(data: ICreateUserDTO): Promise<UserDates>;
@@ -7,6 +14,8 @@ export interface IUsersRepository {
   findAdmin(): Promise<UserDates>;
   update(data: IUpdateUserDTO): Promise<UserDates>;
   deleteAddress(userId: number, addressId: number): Promise<void>;
+  createAddress(data: ICreateAddressRequestDTO): Promise<AddressDates>;
+  updateAddress(data: IUpdateAddressRequestDTO): Promise<AddressDates>;
   findAll(data: {
     page: number;
     limit: number;

--- a/src/modules/accounts/types.ts
+++ b/src/modules/accounts/types.ts
@@ -64,7 +64,6 @@ export interface IUpdateUserDTO {
   id: number;
   username?: string;
   telephone?: string;
-  addresses?: Partial<AddressDates>[];
 }
 
 export interface ICreateAddressDTO {
@@ -75,4 +74,15 @@ export interface ICreateAddressDTO {
   number: string;
   user_id: number;
   isDefault?: boolean;
+}
+
+export interface ICreateAddressRequestDTO {
+  userId: number;
+  address: Omit<AddressDates, "id" | "user_id" | "isDefault">;
+}
+
+export interface IUpdateAddressRequestDTO {
+  userId: number;
+  addressId: number;
+  address: Partial<Omit<AddressDates, "id" | "user_id">>;
 }

--- a/src/modules/accounts/useCases/createAddress/createAddressController.test.ts
+++ b/src/modules/accounts/useCases/createAddress/createAddressController.test.ts
@@ -1,0 +1,93 @@
+import { Request, Response } from "express";
+import { container } from "tsyringe";
+
+import { AppError } from "@shared/errors/AppError";
+
+import { CreateAddressController } from "./createAddressController";
+
+describe("CreateAddressController", () => {
+  let createAddressController: CreateAddressController;
+  let mockRequest: Partial<Request>;
+  let mockResponse: Partial<Response>;
+  let statusMock: jest.Mock;
+  let jsonMock: jest.Mock;
+
+  beforeEach(() => {
+    createAddressController = new CreateAddressController();
+
+    statusMock = jest.fn().mockReturnThis();
+    jsonMock = jest.fn().mockReturnValue({} as Response);
+
+    mockResponse = {
+      status: statusMock,
+      json: jsonMock,
+    };
+
+    jest.clearAllMocks();
+  });
+
+  it("should create address successfully and return 201", async () => {
+    const mockCreatedAddress = {
+      id: 1,
+      street: "Rua Teste",
+      number: "123",
+      reference: "Próximo ao shopping",
+      local: "São Paulo",
+      user_id: 123,
+      isDefault: true,
+    };
+
+    jest.spyOn(container, "resolve").mockImplementation(() => ({
+      execute: jest.fn().mockResolvedValue(mockCreatedAddress),
+    }));
+
+    mockRequest = {
+      user: { id: "123", role: "USER" },
+      body: {
+        street: "Rua Teste",
+        number: "123",
+        reference: "Próximo ao shopping",
+        local: "São Paulo",
+      },
+    };
+
+    await createAddressController.handle(
+      mockRequest as Request,
+      mockResponse as Response
+    );
+
+    expect(statusMock).toHaveBeenCalledWith(201);
+    expect(jsonMock).toHaveBeenCalledWith(mockCreatedAddress);
+  });
+
+  it("should return 400 if useCase throws an error", async () => {
+    const mockError = new AppError({
+      message: "Usuário pode ter no máximo 5 endereços",
+      statusCode: 400,
+    });
+
+    jest.spyOn(container, "resolve").mockImplementation(() => ({
+      execute: jest.fn().mockRejectedValue(mockError),
+    }));
+
+    mockRequest = {
+      user: { id: "123", role: "USER" },
+      body: {
+        street: "Rua Teste",
+        number: "123",
+        reference: "Próximo ao shopping",
+        local: "São Paulo",
+      },
+    };
+
+    await createAddressController.handle(
+      mockRequest as Request,
+      mockResponse as Response
+    );
+
+    expect(statusMock).toHaveBeenCalledWith(400);
+    expect(jsonMock).toHaveBeenCalledWith({
+      message: "Usuário pode ter no máximo 5 endereços",
+    });
+  });
+});

--- a/src/modules/accounts/useCases/createAddress/createAddressController.ts
+++ b/src/modules/accounts/useCases/createAddress/createAddressController.ts
@@ -1,0 +1,26 @@
+import { Request, Response } from "express";
+import { container } from "tsyringe";
+
+import { handleControllerError } from "@shared/utils/controller";
+
+import { CreateAddressUseCase } from "./createAddressUseCase";
+
+export class CreateAddressController {
+  async handle(request: Request, response: Response): Promise<Response> {
+    try {
+      const { id: userId } = request.user;
+      const address = request.body;
+
+      const createAddressUseCase = container.resolve(CreateAddressUseCase);
+
+      const createdAddress = await createAddressUseCase.execute({
+        userId: parseInt(userId, 10),
+        address,
+      });
+
+      return response.status(201).json(createdAddress);
+    } catch (error) {
+      return handleControllerError(error, response);
+    }
+  }
+}

--- a/src/modules/accounts/useCases/createAddress/createAddressUseCase.test.ts
+++ b/src/modules/accounts/useCases/createAddress/createAddressUseCase.test.ts
@@ -1,0 +1,111 @@
+import { CreateAddressUseCase } from "./createAddressUseCase";
+
+describe("CreateAddressUseCase", () => {
+  let createAddressUseCase: CreateAddressUseCase;
+  const mockUsersRepository = {
+    findById: jest.fn(),
+    createAddress: jest.fn(),
+  };
+
+  beforeEach(() => {
+    createAddressUseCase = new CreateAddressUseCase(mockUsersRepository as any);
+    jest.clearAllMocks();
+  });
+
+  it("should create address successfully", async () => {
+    const userId = 123;
+    const addressData = {
+      street: "Rua Teste",
+      number: "123",
+      reference: "Próximo ao shopping",
+      local: "São Paulo",
+    };
+
+    const mockUser = {
+      id: userId,
+      addresses: [],
+    };
+
+    const mockCreatedAddress = {
+      id: 1,
+      ...addressData,
+      user_id: userId,
+      isDefault: true,
+    };
+
+    mockUsersRepository.findById.mockResolvedValue(mockUser);
+    mockUsersRepository.createAddress.mockResolvedValue(mockCreatedAddress);
+
+    const result = await createAddressUseCase.execute({
+      userId,
+      address: addressData,
+    });
+
+    expect(mockUsersRepository.findById).toHaveBeenCalledWith(userId);
+    expect(mockUsersRepository.createAddress).toHaveBeenCalledWith({
+      userId,
+      address: { ...addressData, isDefault: true },
+    });
+    expect(result).toEqual(mockCreatedAddress);
+  });
+
+  it("should throw error when user has 5 addresses", async () => {
+    const userId = 123;
+    const addressData = {
+      street: "Rua Teste",
+      number: "123",
+      reference: "Próximo ao shopping",
+      local: "São Paulo",
+    };
+
+    const mockUser = {
+      id: userId,
+      addresses: [{ id: 1 }, { id: 2 }, { id: 3 }, { id: 4 }, { id: 5 }],
+    };
+
+    mockUsersRepository.findById.mockResolvedValue(mockUser);
+
+    await expect(
+      createAddressUseCase.execute({
+        userId,
+        address: addressData,
+      })
+    ).rejects.toThrow("Usuário pode ter no máximo 5 endereços");
+  });
+
+  it("should set isDefault to false when user already has addresses", async () => {
+    const userId = 123;
+    const addressData = {
+      street: "Rua Teste",
+      number: "123",
+      reference: "Próximo ao shopping",
+      local: "São Paulo",
+    };
+
+    const mockUser = {
+      id: userId,
+      addresses: [{ id: 1 }],
+    };
+
+    const mockCreatedAddress = {
+      id: 2,
+      ...addressData,
+      user_id: userId,
+      isDefault: false,
+    };
+
+    mockUsersRepository.findById.mockResolvedValue(mockUser);
+    mockUsersRepository.createAddress.mockResolvedValue(mockCreatedAddress);
+
+    const result = await createAddressUseCase.execute({
+      userId,
+      address: addressData,
+    });
+
+    expect(mockUsersRepository.createAddress).toHaveBeenCalledWith({
+      userId,
+      address: { ...addressData, isDefault: false },
+    });
+    expect(result).toEqual(mockCreatedAddress);
+  });
+});

--- a/src/modules/accounts/useCases/createAddress/createAddressUseCase.ts
+++ b/src/modules/accounts/useCases/createAddress/createAddressUseCase.ts
@@ -1,0 +1,35 @@
+import { IUsersRepository } from "@modules/accounts/repositories/interfaces/IUserRepository";
+import {
+  AddressDates,
+  ICreateAddressRequestDTO,
+} from "@modules/accounts/types";
+import { inject, injectable } from "tsyringe";
+
+import { AppError } from "@shared/errors/AppError";
+
+@injectable()
+export class CreateAddressUseCase {
+  constructor(
+    @inject("UsersRepository")
+    private usersRepository: IUsersRepository
+  ) {}
+
+  async execute(data: ICreateAddressRequestDTO): Promise<AddressDates> {
+    const { userId, address } = data;
+
+    const currentUser = await this.usersRepository.findById(userId);
+    if (currentUser.addresses.length >= 5) {
+      throw new AppError({
+        message: "Usuário pode ter no máximo 5 endereços",
+        statusCode: 400,
+      });
+    }
+
+    const isDefault = currentUser.addresses.length === 0;
+
+    return this.usersRepository.createAddress({
+      userId,
+      address: { ...address, isDefault } as any,
+    });
+  }
+}

--- a/src/modules/accounts/useCases/deleteAddress/deleteAddressController.test.ts
+++ b/src/modules/accounts/useCases/deleteAddress/deleteAddressController.test.ts
@@ -1,0 +1,70 @@
+import { Request, Response } from "express";
+import { container } from "tsyringe";
+
+import { DeleteAddressController } from "./deleteAddressController";
+
+describe("DeleteAddressController", () => {
+  let deleteAddressController: DeleteAddressController;
+  let mockRequest: Partial<Request>;
+  let mockResponse: Partial<Response>;
+  let statusMock: jest.Mock;
+  let sendMock: jest.Mock;
+  let jsonMock: jest.Mock;
+
+  beforeEach(() => {
+    deleteAddressController = new DeleteAddressController();
+
+    statusMock = jest.fn().mockReturnThis();
+    sendMock = jest.fn().mockReturnValue({} as Response);
+    jsonMock = jest.fn().mockReturnValue({} as Response);
+
+    mockResponse = {
+      status: statusMock,
+      send: sendMock,
+      json: jsonMock,
+    };
+
+    jest.clearAllMocks();
+  });
+
+  it("should delete address successfully and return 204", async () => {
+    jest.spyOn(container, "resolve").mockImplementation(() => ({
+      execute: jest.fn().mockResolvedValue(undefined),
+    }));
+
+    mockRequest = {
+      user: { id: "123", role: "USER" },
+      params: { addressId: "456" },
+    };
+
+    await deleteAddressController.handle(
+      mockRequest as Request,
+      mockResponse as Response
+    );
+
+    expect(statusMock).toHaveBeenCalledWith(204);
+    expect(sendMock).toHaveBeenCalledWith();
+  });
+
+  it("should return 500 if useCase throws an error", async () => {
+    jest.spyOn(container, "resolve").mockImplementation(() => ({
+      execute: jest.fn().mockRejectedValue(new Error("Internal server error")),
+    }));
+
+    mockRequest = {
+      user: { id: "123", role: "USER" },
+      params: { addressId: "456" },
+    };
+
+    await deleteAddressController.handle(
+      mockRequest as Request,
+      mockResponse as Response
+    );
+
+    expect(statusMock).toHaveBeenCalledWith(500);
+    expect(jsonMock).toHaveBeenCalledWith({
+      message: "Erro interno do servidor",
+      unexpectedErrorMsg: "Internal server error",
+    });
+  });
+});

--- a/src/modules/accounts/useCases/deleteAddress/deleteAddressController.ts
+++ b/src/modules/accounts/useCases/deleteAddress/deleteAddressController.ts
@@ -1,0 +1,26 @@
+import { Request, Response } from "express";
+import { container } from "tsyringe";
+
+import { handleControllerError } from "@shared/utils/controller";
+
+import { DeleteAddressUseCase } from "./deleteAddressUseCase";
+
+export class DeleteAddressController {
+  async handle(request: Request, response: Response): Promise<Response> {
+    try {
+      const { id: userId } = request.user;
+      const { addressId } = request.params;
+
+      const deleteAddressUseCase = container.resolve(DeleteAddressUseCase);
+
+      await deleteAddressUseCase.execute(
+        parseInt(userId, 10),
+        parseInt(addressId, 10)
+      );
+
+      return response.status(204).send();
+    } catch (error) {
+      return handleControllerError(error, response);
+    }
+  }
+}

--- a/src/modules/accounts/useCases/deleteAddress/deleteAddressUseCase.test.ts
+++ b/src/modules/accounts/useCases/deleteAddress/deleteAddressUseCase.test.ts
@@ -1,0 +1,41 @@
+import { DeleteAddressUseCase } from "./deleteAddressUseCase";
+
+describe("DeleteAddressUseCase", () => {
+  let useCase: DeleteAddressUseCase;
+  const mockUsersRepository = {
+    deleteAddress: jest.fn(),
+  };
+
+  beforeEach(() => {
+    useCase = new DeleteAddressUseCase(mockUsersRepository as any);
+    jest.clearAllMocks();
+  });
+
+  it("should delete address successfully", async () => {
+    const userId = 123;
+    const addressId = 456;
+
+    mockUsersRepository.deleteAddress.mockResolvedValue(undefined);
+
+    await useCase.execute(userId, addressId);
+
+    expect(mockUsersRepository.deleteAddress).toHaveBeenCalledWith(
+      userId,
+      addressId
+    );
+    expect(mockUsersRepository.deleteAddress).toHaveBeenCalledTimes(1);
+  });
+
+  it("should throw error if repository throws", async () => {
+    const userId = 123;
+    const addressId = 456;
+
+    mockUsersRepository.deleteAddress.mockRejectedValue(
+      new Error("Erro interno do servidor")
+    );
+
+    await expect(useCase.execute(userId, addressId)).rejects.toThrow(
+      "Erro interno do servidor"
+    );
+  });
+});

--- a/src/modules/accounts/useCases/deleteAddress/deleteAddressUseCase.ts
+++ b/src/modules/accounts/useCases/deleteAddress/deleteAddressUseCase.ts
@@ -1,0 +1,14 @@
+import { IUsersRepository } from "@modules/accounts/repositories/interfaces/IUserRepository";
+import { inject, injectable } from "tsyringe";
+
+@injectable()
+export class DeleteAddressUseCase {
+  constructor(
+    @inject("UsersRepository")
+    private usersRepository: IUsersRepository
+  ) {}
+
+  async execute(userId: number, addressId: number): Promise<void> {
+    await this.usersRepository.deleteAddress(userId, addressId);
+  }
+}

--- a/src/modules/accounts/useCases/updateAddress/updateAddressController.test.ts
+++ b/src/modules/accounts/useCases/updateAddress/updateAddressController.test.ts
@@ -1,0 +1,90 @@
+import { Request, Response } from "express";
+import { container } from "tsyringe";
+
+import { AppError } from "@shared/errors/AppError";
+
+import { UpdateAddressController } from "./updateAddressController";
+
+describe("UpdateAddressController", () => {
+  let updateAddressController: UpdateAddressController;
+  let mockRequest: Partial<Request>;
+  let mockResponse: Partial<Response>;
+  let statusMock: jest.Mock;
+  let jsonMock: jest.Mock;
+
+  beforeEach(() => {
+    updateAddressController = new UpdateAddressController();
+
+    statusMock = jest.fn().mockReturnThis();
+    jsonMock = jest.fn().mockReturnValue({} as Response);
+
+    mockResponse = {
+      status: statusMock,
+      json: jsonMock,
+    };
+
+    jest.clearAllMocks();
+  });
+
+  it("should update address successfully and return 200", async () => {
+    const mockUpdatedAddress = {
+      id: 456,
+      street: "Rua Atualizada",
+      number: "456",
+      reference: "Próximo ao shopping",
+      local: "São Paulo",
+      user_id: 123,
+    };
+
+    jest.spyOn(container, "resolve").mockImplementation(() => ({
+      execute: jest.fn().mockResolvedValue(mockUpdatedAddress),
+    }));
+
+    mockRequest = {
+      user: { id: "123", role: "USER" },
+      params: { addressId: "456" },
+      body: {
+        street: "Rua Atualizada",
+        number: "456",
+      },
+    };
+
+    await updateAddressController.handle(
+      mockRequest as Request,
+      mockResponse as Response
+    );
+
+    expect(statusMock).toHaveBeenCalledWith(200);
+    expect(jsonMock).toHaveBeenCalledWith(mockUpdatedAddress);
+  });
+
+  it("should return 404 if address not found", async () => {
+    const mockError = new AppError({
+      message: "Endereço não encontrado",
+      statusCode: 404,
+    });
+
+    jest.spyOn(container, "resolve").mockImplementation(() => ({
+      execute: jest.fn().mockRejectedValue(mockError),
+    }));
+
+    mockRequest = {
+      user: { id: "123", role: "USER" },
+      params: { addressId: "999" },
+      body: {
+        street: "Rua Atualizada",
+        number: "456",
+      },
+    };
+
+    await updateAddressController.handle(
+      mockRequest as Request,
+      mockResponse as Response
+    );
+
+    expect(statusMock).toHaveBeenCalledWith(404);
+    expect(jsonMock).toHaveBeenCalledWith({
+      message: "Endereço não encontrado",
+    });
+  });
+});

--- a/src/modules/accounts/useCases/updateAddress/updateAddressController.ts
+++ b/src/modules/accounts/useCases/updateAddress/updateAddressController.ts
@@ -1,0 +1,28 @@
+import { Request, Response } from "express";
+import { container } from "tsyringe";
+
+import { handleControllerError } from "@shared/utils/controller";
+
+import { UpdateAddressUseCase } from "./updateAddressUseCase";
+
+export class UpdateAddressController {
+  async handle(request: Request, response: Response): Promise<Response> {
+    try {
+      const { id: userId } = request.user;
+      const { addressId } = request.params;
+      const address = request.body;
+
+      const updateAddressUseCase = container.resolve(UpdateAddressUseCase);
+
+      const updatedAddress = await updateAddressUseCase.execute({
+        userId: Number(userId),
+        addressId: Number(addressId),
+        address,
+      });
+
+      return response.status(200).json(updatedAddress);
+    } catch (error) {
+      return handleControllerError(error, response);
+    }
+  }
+}

--- a/src/modules/accounts/useCases/updateAddress/updateAddressUseCase.test.ts
+++ b/src/modules/accounts/useCases/updateAddress/updateAddressUseCase.test.ts
@@ -1,0 +1,105 @@
+import { UpdateAddressUseCase } from "./updateAddressUseCase";
+
+describe("UpdateAddressUseCase", () => {
+  let updateAddressUseCase: UpdateAddressUseCase;
+  const mockUsersRepository = {
+    findById: jest.fn(),
+    updateAddress: jest.fn(),
+  };
+
+  beforeEach(() => {
+    updateAddressUseCase = new UpdateAddressUseCase(mockUsersRepository as any);
+    jest.clearAllMocks();
+  });
+
+  it("should update address successfully", async () => {
+    const userId = 123;
+    const addressId = 456;
+    const addressData = {
+      street: "Rua Atualizada",
+      number: "456",
+    };
+
+    const mockUser = {
+      id: userId,
+      addresses: [
+        { id: addressId, street: "Rua Antiga", number: "123" },
+        { id: 789, street: "Outra Rua", number: "999" },
+      ],
+    };
+
+    const mockUpdatedAddress = {
+      id: addressId,
+      ...addressData,
+      user_id: userId,
+    };
+
+    mockUsersRepository.findById.mockResolvedValue(mockUser);
+    mockUsersRepository.updateAddress.mockResolvedValue(mockUpdatedAddress);
+
+    const result = await updateAddressUseCase.execute({
+      userId,
+      addressId,
+      address: addressData,
+    });
+
+    expect(mockUsersRepository.findById).toHaveBeenCalledWith(userId);
+    expect(mockUsersRepository.updateAddress).toHaveBeenCalledWith({
+      userId,
+      addressId,
+      address: addressData,
+    });
+    expect(result).toEqual(mockUpdatedAddress);
+  });
+
+  it("should throw error when address not found", async () => {
+    const userId = 123;
+    const addressId = 999;
+    const addressData = {
+      street: "Rua Atualizada",
+      number: "456",
+    };
+
+    const mockUser = {
+      id: userId,
+      addresses: [
+        { id: 456, street: "Rua Antiga", number: "123" },
+        { id: 789, street: "Outra Rua", number: "999" },
+      ],
+    };
+
+    mockUsersRepository.findById.mockResolvedValue(mockUser);
+
+    await expect(
+      updateAddressUseCase.execute({
+        userId,
+        addressId,
+        address: addressData,
+      })
+    ).rejects.toThrow("Endereço não encontrado");
+  });
+
+  it("should throw error when address does not belong to user", async () => {
+    const userId = 123;
+    const addressId = 456;
+    const addressData = {
+      street: "Rua Atualizada",
+      number: "456",
+    };
+
+    const mockUser = {
+      id: userId,
+      addresses: [{ id: 789, street: "Outra Rua", number: "999" }],
+    };
+
+    mockUsersRepository.findById.mockResolvedValue(mockUser);
+
+    await expect(
+      updateAddressUseCase.execute({
+        userId,
+        addressId,
+        address: addressData,
+      })
+    ).rejects.toThrow("Endereço não encontrado");
+  });
+});

--- a/src/modules/accounts/useCases/updateAddress/updateAddressUseCase.ts
+++ b/src/modules/accounts/useCases/updateAddress/updateAddressUseCase.ts
@@ -1,0 +1,38 @@
+import { IUsersRepository } from "@modules/accounts/repositories/interfaces/IUserRepository";
+import {
+  AddressDates,
+  IUpdateAddressRequestDTO,
+} from "@modules/accounts/types";
+import { inject, injectable } from "tsyringe";
+
+import { AppError } from "@shared/errors/AppError";
+
+@injectable()
+export class UpdateAddressUseCase {
+  constructor(
+    @inject("UsersRepository")
+    private usersRepository: IUsersRepository
+  ) {}
+
+  async execute(data: IUpdateAddressRequestDTO): Promise<AddressDates> {
+    const { userId, addressId, address } = data;
+
+    const currentUser = await this.usersRepository.findById(userId);
+    const existingAddress = currentUser.addresses.find(
+      (addr) => addr.id === addressId
+    );
+
+    if (!existingAddress) {
+      throw new AppError({
+        message: "Endereço não encontrado",
+        statusCode: 404,
+      });
+    }
+
+    return this.usersRepository.updateAddress({
+      userId,
+      addressId,
+      address,
+    });
+  }
+}

--- a/src/modules/accounts/useCases/updateUser/updateUserUsecase.test.ts
+++ b/src/modules/accounts/useCases/updateUser/updateUserUsecase.test.ts
@@ -5,12 +5,14 @@ import {
   UserDates,
 } from "@modules/accounts/types";
 
+import { AppError } from "@shared/errors/AppError";
 import { UpdateUserUseCase } from "./updateUserUsecase";
 
 describe("UpdateUserUseCase", () => {
   let useCase: UpdateUserUseCase;
   const mockUsersRepository = {
     update: jest.fn(),
+    findById: jest.fn(),
   };
 
   beforeEach(() => {
@@ -59,6 +61,16 @@ describe("UpdateUserUseCase", () => {
       notificationTokens: [],
     };
 
+    mockUsersRepository.findById.mockResolvedValue({
+      id: 123,
+      username: "existingUser",
+      email: "existing@example.com",
+      password: "hashed_password",
+      role: "USER",
+      created_at: new Date(),
+      telephone: "81999999999",
+      addresses: [],
+    });
     mockUsersRepository.update.mockResolvedValue(updatedUser);
     const toDTOSpy = jest.spyOn(UserMap, "toDTO").mockReturnValue(expectedDTO);
 
@@ -123,5 +135,173 @@ describe("UpdateUserUseCase", () => {
       "Erro interno do servidor"
     );
     expect(mockUsersRepository.update).toHaveBeenCalledWith(updateData);
+  });
+
+  it("should throw AppError when trying to add more than 5 addresses", async () => {
+    const currentUser: UserDates = {
+      id: 123,
+      username: "existingUser",
+      email: "existing@example.com",
+      password: "hashed_password",
+      role: "USER",
+      created_at: new Date(),
+      telephone: "81999999999",
+      addresses: [
+        { id: 1, street: "Rua 1", reference: "Ref 1", local: "Local 1" },
+        { id: 2, street: "Rua 2", reference: "Ref 2", local: "Local 2" },
+        { id: 3, street: "Rua 3", reference: "Ref 3", local: "Local 3" },
+        { id: 4, street: "Rua 4", reference: "Ref 4", local: "Local 4" },
+      ],
+    };
+
+    const updateData: IUpdateUserDTO = {
+      id: 123,
+      username: "updatedUser",
+      addresses: [
+        {
+          id: 1,
+          street: "Rua 1 Updated",
+          reference: "Ref 1",
+          local: "Local 1",
+        }, // Update existing
+        {
+          street: "Rua Nova 1",
+          reference: "Ref Nova 1",
+          local: "Local Nova 1",
+        }, // New address
+        {
+          street: "Rua Nova 2",
+          reference: "Ref Nova 2",
+          local: "Local Nova 2",
+        }, // New address
+      ],
+    };
+
+    mockUsersRepository.findById.mockResolvedValue(currentUser);
+
+    await expect(useCase.execute(updateData)).rejects.toThrow(AppError);
+    await expect(useCase.execute(updateData)).rejects.toThrow(
+      "Usuário pode ter no máximo 5 endereços"
+    );
+  });
+
+  it("should allow adding new addresses when under the limit", async () => {
+    const currentUser: UserDates = {
+      id: 123,
+      username: "existingUser",
+      email: "existing@example.com",
+      password: "hashed_password",
+      role: "USER",
+      created_at: new Date(),
+      telephone: "81999999999",
+      addresses: [
+        { id: 1, street: "Rua 1", reference: "Ref 1", local: "Local 1" },
+        { id: 2, street: "Rua 2", reference: "Ref 2", local: "Local 2" },
+      ],
+    };
+
+    const updateData: IUpdateUserDTO = {
+      id: 123,
+      username: "updatedUser",
+      addresses: [
+        {
+          id: 1,
+          street: "Rua 1 Updated",
+          reference: "Ref 1",
+          local: "Local 1",
+        }, // Update existing
+        {
+          street: "Rua Nova 1",
+          reference: "Ref Nova 1",
+          local: "Local Nova 1",
+        }, // New address
+        {
+          street: "Rua Nova 2",
+          reference: "Ref Nova 2",
+          local: "Local Nova 2",
+        }, // New address
+      ],
+    };
+
+    const updatedUser: UserDates = {
+      ...currentUser,
+      username: "updatedUser",
+      addresses: [
+        {
+          id: 1,
+          street: "Rua 1 Updated",
+          reference: "Ref 1",
+          local: "Local 1",
+        },
+        { id: 2, street: "Rua 2", reference: "Ref 2", local: "Local 2" },
+        {
+          id: 5,
+          street: "Rua Nova 1",
+          reference: "Ref Nova 1",
+          local: "Local Nova 1",
+        },
+        {
+          id: 6,
+          street: "Rua Nova 2",
+          reference: "Ref Nova 2",
+          local: "Local Nova 2",
+        },
+      ],
+    };
+
+    const expectedDTO: IUserResponseDTO = {
+      id: 123,
+      username: "updatedUser",
+      email: "existing@example.com",
+      role: "USER",
+      notificationTokens: [],
+    };
+
+    mockUsersRepository.findById.mockResolvedValue(currentUser);
+    mockUsersRepository.update.mockResolvedValue(updatedUser);
+    const toDTOSpy = jest.spyOn(UserMap, "toDTO").mockReturnValue(expectedDTO);
+
+    const result = await useCase.execute(updateData);
+
+    expect(mockUsersRepository.findById).toHaveBeenCalledWith(123);
+    expect(mockUsersRepository.update).toHaveBeenCalledWith(updateData);
+    expect(toDTOSpy).toHaveBeenCalledWith(updatedUser);
+    expect(result).toEqual(expectedDTO);
+  });
+
+  it("should not validate address limit when no addresses are provided", async () => {
+    const updateData: IUpdateUserDTO = {
+      id: 123,
+      username: "updatedUser",
+    };
+
+    const updatedUser: UserDates = {
+      id: 123,
+      username: "updatedUser",
+      email: "existing@example.com",
+      password: "hashed_password",
+      role: "USER",
+      created_at: new Date(),
+      telephone: "81999999999",
+      addresses: [],
+    };
+
+    const expectedDTO: IUserResponseDTO = {
+      id: 123,
+      username: "updatedUser",
+      email: "existing@example.com",
+      role: "USER",
+      notificationTokens: [],
+    };
+
+    mockUsersRepository.update.mockResolvedValue(updatedUser);
+    const toDTOSpy = jest.spyOn(UserMap, "toDTO").mockReturnValue(expectedDTO);
+
+    const result = await useCase.execute(updateData);
+
+    expect(mockUsersRepository.findById).not.toHaveBeenCalled();
+    expect(mockUsersRepository.update).toHaveBeenCalledWith(updateData);
+    expect(toDTOSpy).toHaveBeenCalledWith(updatedUser);
+    expect(result).toEqual(expectedDTO);
   });
 });

--- a/src/modules/accounts/useCases/updateUser/updateUserUsecase.test.ts
+++ b/src/modules/accounts/useCases/updateUser/updateUserUsecase.test.ts
@@ -5,7 +5,6 @@ import {
   UserDates,
 } from "@modules/accounts/types";
 
-import { AppError } from "@shared/errors/AppError";
 import { UpdateUserUseCase } from "./updateUserUsecase";
 
 describe("UpdateUserUseCase", () => {
@@ -25,14 +24,6 @@ describe("UpdateUserUseCase", () => {
       id: 123,
       username: "updatedUser",
       telephone: "11987654321",
-      addresses: [
-        {
-          street: "New Street",
-          number: "456",
-          reference: "New Reference",
-          local: "New City",
-        },
-      ],
     };
 
     const updatedUser: UserDates = {
@@ -135,173 +126,5 @@ describe("UpdateUserUseCase", () => {
       "Erro interno do servidor"
     );
     expect(mockUsersRepository.update).toHaveBeenCalledWith(updateData);
-  });
-
-  it("should throw AppError when trying to add more than 5 addresses", async () => {
-    const currentUser: UserDates = {
-      id: 123,
-      username: "existingUser",
-      email: "existing@example.com",
-      password: "hashed_password",
-      role: "USER",
-      created_at: new Date(),
-      telephone: "81999999999",
-      addresses: [
-        { id: 1, street: "Rua 1", reference: "Ref 1", local: "Local 1" },
-        { id: 2, street: "Rua 2", reference: "Ref 2", local: "Local 2" },
-        { id: 3, street: "Rua 3", reference: "Ref 3", local: "Local 3" },
-        { id: 4, street: "Rua 4", reference: "Ref 4", local: "Local 4" },
-      ],
-    };
-
-    const updateData: IUpdateUserDTO = {
-      id: 123,
-      username: "updatedUser",
-      addresses: [
-        {
-          id: 1,
-          street: "Rua 1 Updated",
-          reference: "Ref 1",
-          local: "Local 1",
-        }, // Update existing
-        {
-          street: "Rua Nova 1",
-          reference: "Ref Nova 1",
-          local: "Local Nova 1",
-        }, // New address
-        {
-          street: "Rua Nova 2",
-          reference: "Ref Nova 2",
-          local: "Local Nova 2",
-        }, // New address
-      ],
-    };
-
-    mockUsersRepository.findById.mockResolvedValue(currentUser);
-
-    await expect(useCase.execute(updateData)).rejects.toThrow(AppError);
-    await expect(useCase.execute(updateData)).rejects.toThrow(
-      "Usuário pode ter no máximo 5 endereços"
-    );
-  });
-
-  it("should allow adding new addresses when under the limit", async () => {
-    const currentUser: UserDates = {
-      id: 123,
-      username: "existingUser",
-      email: "existing@example.com",
-      password: "hashed_password",
-      role: "USER",
-      created_at: new Date(),
-      telephone: "81999999999",
-      addresses: [
-        { id: 1, street: "Rua 1", reference: "Ref 1", local: "Local 1" },
-        { id: 2, street: "Rua 2", reference: "Ref 2", local: "Local 2" },
-      ],
-    };
-
-    const updateData: IUpdateUserDTO = {
-      id: 123,
-      username: "updatedUser",
-      addresses: [
-        {
-          id: 1,
-          street: "Rua 1 Updated",
-          reference: "Ref 1",
-          local: "Local 1",
-        }, // Update existing
-        {
-          street: "Rua Nova 1",
-          reference: "Ref Nova 1",
-          local: "Local Nova 1",
-        }, // New address
-        {
-          street: "Rua Nova 2",
-          reference: "Ref Nova 2",
-          local: "Local Nova 2",
-        }, // New address
-      ],
-    };
-
-    const updatedUser: UserDates = {
-      ...currentUser,
-      username: "updatedUser",
-      addresses: [
-        {
-          id: 1,
-          street: "Rua 1 Updated",
-          reference: "Ref 1",
-          local: "Local 1",
-        },
-        { id: 2, street: "Rua 2", reference: "Ref 2", local: "Local 2" },
-        {
-          id: 5,
-          street: "Rua Nova 1",
-          reference: "Ref Nova 1",
-          local: "Local Nova 1",
-        },
-        {
-          id: 6,
-          street: "Rua Nova 2",
-          reference: "Ref Nova 2",
-          local: "Local Nova 2",
-        },
-      ],
-    };
-
-    const expectedDTO: IUserResponseDTO = {
-      id: 123,
-      username: "updatedUser",
-      email: "existing@example.com",
-      role: "USER",
-      notificationTokens: [],
-    };
-
-    mockUsersRepository.findById.mockResolvedValue(currentUser);
-    mockUsersRepository.update.mockResolvedValue(updatedUser);
-    const toDTOSpy = jest.spyOn(UserMap, "toDTO").mockReturnValue(expectedDTO);
-
-    const result = await useCase.execute(updateData);
-
-    expect(mockUsersRepository.findById).toHaveBeenCalledWith(123);
-    expect(mockUsersRepository.update).toHaveBeenCalledWith(updateData);
-    expect(toDTOSpy).toHaveBeenCalledWith(updatedUser);
-    expect(result).toEqual(expectedDTO);
-  });
-
-  it("should not validate address limit when no addresses are provided", async () => {
-    const updateData: IUpdateUserDTO = {
-      id: 123,
-      username: "updatedUser",
-    };
-
-    const updatedUser: UserDates = {
-      id: 123,
-      username: "updatedUser",
-      email: "existing@example.com",
-      password: "hashed_password",
-      role: "USER",
-      created_at: new Date(),
-      telephone: "81999999999",
-      addresses: [],
-    };
-
-    const expectedDTO: IUserResponseDTO = {
-      id: 123,
-      username: "updatedUser",
-      email: "existing@example.com",
-      role: "USER",
-      notificationTokens: [],
-    };
-
-    mockUsersRepository.update.mockResolvedValue(updatedUser);
-    const toDTOSpy = jest.spyOn(UserMap, "toDTO").mockReturnValue(expectedDTO);
-
-    const result = await useCase.execute(updateData);
-
-    expect(mockUsersRepository.findById).not.toHaveBeenCalled();
-    expect(mockUsersRepository.update).toHaveBeenCalledWith(updateData);
-    expect(toDTOSpy).toHaveBeenCalledWith(updatedUser);
-    expect(result).toEqual(expectedDTO);
   });
 });

--- a/src/modules/accounts/useCases/updateUser/updateUserUsecase.ts
+++ b/src/modules/accounts/useCases/updateUser/updateUserUsecase.ts
@@ -1,7 +1,13 @@
 import { UserMap } from "@modules/accounts/mapper/UserMapper";
 import { IUsersRepository } from "@modules/accounts/repositories/interfaces/IUserRepository";
-import { IUpdateUserDTO, IUserResponseDTO } from "@modules/accounts/types";
+import {
+  AddressDates,
+  IUpdateUserDTO,
+  IUserResponseDTO,
+} from "@modules/accounts/types";
 import { inject, injectable } from "tsyringe";
+
+import { AppError } from "@shared/errors/AppError";
 
 @injectable()
 export class UpdateUserUseCase {
@@ -11,8 +17,29 @@ export class UpdateUserUseCase {
   ) {}
 
   async execute(data: IUpdateUserDTO): Promise<IUserResponseDTO> {
+    if (data.addresses) {
+      await this.validateAddressLimit(data.id, data.addresses);
+    }
+
     const user = await this.usersRepository.update(data);
 
     return UserMap.toDTO(user);
+  }
+
+  private async validateAddressLimit(
+    userId: number,
+    addresses: Partial<AddressDates>[]
+  ): Promise<void> {
+    const currentUser = await this.usersRepository.findById(userId);
+    const currentAddressCount = currentUser.addresses.length;
+    const newAddressesCount = addresses.filter((addr) => !addr.id).length;
+    const totalAfterUpdate = currentAddressCount + newAddressesCount;
+
+    if (totalAfterUpdate > 5) {
+      throw new AppError({
+        message: "Usuário pode ter no máximo 5 endereços",
+        statusCode: 400,
+      });
+    }
   }
 }

--- a/src/modules/accounts/useCases/updateUser/updateUserUsecase.ts
+++ b/src/modules/accounts/useCases/updateUser/updateUserUsecase.ts
@@ -1,13 +1,7 @@
 import { UserMap } from "@modules/accounts/mapper/UserMapper";
 import { IUsersRepository } from "@modules/accounts/repositories/interfaces/IUserRepository";
-import {
-  AddressDates,
-  IUpdateUserDTO,
-  IUserResponseDTO,
-} from "@modules/accounts/types";
+import { IUpdateUserDTO, IUserResponseDTO } from "@modules/accounts/types";
 import { inject, injectable } from "tsyringe";
-
-import { AppError } from "@shared/errors/AppError";
 
 @injectable()
 export class UpdateUserUseCase {
@@ -17,29 +11,12 @@ export class UpdateUserUseCase {
   ) {}
 
   async execute(data: IUpdateUserDTO): Promise<IUserResponseDTO> {
-    if (data.addresses) {
-      await this.validateAddressLimit(data.id, data.addresses);
-    }
-
-    const user = await this.usersRepository.update(data);
+    const user = await this.usersRepository.update({
+      id: data.id,
+      username: data.username,
+      telephone: data.telephone,
+    });
 
     return UserMap.toDTO(user);
-  }
-
-  private async validateAddressLimit(
-    userId: number,
-    addresses: Partial<AddressDates>[]
-  ): Promise<void> {
-    const currentUser = await this.usersRepository.findById(userId);
-    const currentAddressCount = currentUser.addresses.length;
-    const newAddressesCount = addresses.filter((addr) => !addr.id).length;
-    const totalAfterUpdate = currentAddressCount + newAddressesCount;
-
-    if (totalAfterUpdate > 5) {
-      throw new AppError({
-        message: "Usuário pode ter no máximo 5 endereços",
-        statusCode: 400,
-      });
-    }
   }
 }

--- a/src/modules/orders/services/OrderCreationService.test.ts
+++ b/src/modules/orders/services/OrderCreationService.test.ts
@@ -86,6 +86,8 @@ describe(OrderCreationService.name, () => {
       findAll: jest.fn(),
       findAdmin: jest.fn(),
       deleteAddress: jest.fn(),
+      createAddress: jest.fn(),
+      updateAddress: jest.fn(),
     };
 
     mockOrdersRepository = {

--- a/src/modules/orders/services/OrderCreationService.test.ts
+++ b/src/modules/orders/services/OrderCreationService.test.ts
@@ -85,6 +85,7 @@ describe(OrderCreationService.name, () => {
       update: jest.fn(),
       findAll: jest.fn(),
       findAdmin: jest.fn(),
+      deleteAddress: jest.fn(),
     };
 
     mockOrdersRepository = {

--- a/src/shared/infra/http/routes/users.routes.ts
+++ b/src/shared/infra/http/routes/users.routes.ts
@@ -1,8 +1,10 @@
+import { CreateAddressController } from "@modules/accounts/useCases/createAddress/createAddressController";
 import { CreateUserController } from "@modules/accounts/useCases/createUser/CreateUserController";
 import { DeleteAddressController } from "@modules/accounts/useCases/deleteAddress/deleteAddressController";
 import { ListUserNotificationController } from "@modules/accounts/useCases/ListUserNotificationTokens/ListUserNotificationTokensController";
 import { ListUsersController } from "@modules/accounts/useCases/listUsers/ListUsersController";
 import { ProfileUserController } from "@modules/accounts/useCases/profileUserUseCase/ProfileUserController";
+import { UpdateAddressController } from "@modules/accounts/useCases/updateAddress/updateAddressController";
 import { UpdateUserController } from "@modules/accounts/useCases/updateUser/updateUserController";
 import { UpdateUserNotificationTokensController } from "@modules/accounts/useCases/updateUserNotificationTokens/UpdateUserNotificationTokensController";
 import { SendNewOrderNotificationAdminController } from "@modules/orders/useCases/sendNewOrderNotificationAdmin/SendNewOrderNotificationAdminController";
@@ -14,8 +16,10 @@ import { ensureAuthenticated } from "../middlewares/ensureAuthenticated";
 export const usersRoutes = Router();
 
 const createUserController = new CreateUserController();
+const createAddressController = new CreateAddressController();
 const profileUserController = new ProfileUserController();
 const updateUserController = new UpdateUserController();
+const updateAddressController = new UpdateAddressController();
 const deleteAddressController = new DeleteAddressController();
 const listUsersController = new ListUsersController();
 const sendNotificationController =
@@ -29,6 +33,18 @@ usersRoutes.post("/", createUserController.handle);
 usersRoutes.get("/profile", ensureAuthenticated, profileUserController.handle);
 
 usersRoutes.put("/profile", ensureAuthenticated, updateUserController.handle);
+
+usersRoutes.post(
+  "/addresses",
+  ensureAuthenticated,
+  createAddressController.handle
+);
+
+usersRoutes.put(
+  "/addresses/:addressId",
+  ensureAuthenticated,
+  updateAddressController.handle
+);
 
 usersRoutes.delete(
   "/addresses/:addressId",

--- a/src/shared/infra/http/routes/users.routes.ts
+++ b/src/shared/infra/http/routes/users.routes.ts
@@ -1,4 +1,5 @@
 import { CreateUserController } from "@modules/accounts/useCases/createUser/CreateUserController";
+import { DeleteAddressController } from "@modules/accounts/useCases/deleteAddress/deleteAddressController";
 import { ListUserNotificationController } from "@modules/accounts/useCases/ListUserNotificationTokens/ListUserNotificationTokensController";
 import { ListUsersController } from "@modules/accounts/useCases/listUsers/ListUsersController";
 import { ProfileUserController } from "@modules/accounts/useCases/profileUserUseCase/ProfileUserController";
@@ -15,6 +16,7 @@ export const usersRoutes = Router();
 const createUserController = new CreateUserController();
 const profileUserController = new ProfileUserController();
 const updateUserController = new UpdateUserController();
+const deleteAddressController = new DeleteAddressController();
 const listUsersController = new ListUsersController();
 const sendNotificationController =
   new SendNewOrderNotificationAdminController();
@@ -27,6 +29,12 @@ usersRoutes.post("/", createUserController.handle);
 usersRoutes.get("/profile", ensureAuthenticated, profileUserController.handle);
 
 usersRoutes.put("/profile", ensureAuthenticated, updateUserController.handle);
+
+usersRoutes.delete(
+  "/addresses/:addressId",
+  ensureAuthenticated,
+  deleteAddressController.handle
+);
 
 usersRoutes.get(
   "/list/:page/:limit",

--- a/swagger.json
+++ b/swagger.json
@@ -177,14 +177,19 @@
                     "email": { "type": "string" },
                     "telephone": { "type": "string" },
                     "role": { "type": "string" },
-                    "address": {
-                      "type": "object",
-                      "properties": {
-                        "id": { "type": "integer" },
-                        "street": { "type": "string" },
-                        "number": { "type": "string" },
-                        "reference": { "type": "string" },
-                        "local": { "type": "string" }
+                    "addresses": {
+                      "type": "array",
+                      "description": "Lista de endereços do usuário (máximo 5)",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "id": { "type": "integer" },
+                          "street": { "type": "string" },
+                          "number": { "type": "string" },
+                          "reference": { "type": "string" },
+                          "local": { "type": "string" },
+                          "isDefault": { "type": "boolean" }
+                        }
                       }
                     },
                     "notificationTokens": {
@@ -209,6 +214,7 @@
       },
       "put": {
         "summary": "Atualiza o perfil do usuário autenticado",
+        "description": "Atualiza dados básicos e endereços do usuário. Endereços com ID são atualizados, sem ID são criados. Máximo 5 endereços por usuário.",
         "tags": ["Users"],
         "security": [{ "bearerAuth": [] }],
         "requestBody": {
@@ -218,15 +224,49 @@
               "schema": {
                 "type": "object",
                 "properties": {
-                  "username": { "type": "string" },
-                  "telephone": { "type": "string" },
-                  "address": {
-                    "type": "object",
-                    "properties": {
-                      "street": { "type": "string" },
-                      "number": { "type": "string" },
-                      "reference": { "type": "string" },
-                      "local": { "type": "string" }
+                  "username": {
+                    "type": "string",
+                    "minLength": 3,
+                    "example": "joao_silva_atualizado"
+                  },
+                  "telephone": {
+                    "type": "string",
+                    "pattern": "^[0-9]{11}$",
+                    "example": "11987654321"
+                  },
+                  "addresses": {
+                    "type": "array",
+                    "maxItems": 5,
+                    "description": "Array de endereços. Endereços com ID são atualizados, sem ID são criados.",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "id": {
+                          "type": "integer",
+                          "description": "ID do endereço (opcional para novos endereços)"
+                        },
+                        "street": {
+                          "type": "string",
+                          "example": "Rua das Flores"
+                        },
+                        "number": {
+                          "type": "string",
+                          "example": "123"
+                        },
+                        "reference": {
+                          "type": "string",
+                          "example": "Próximo ao mercado"
+                        },
+                        "local": {
+                          "type": "string",
+                          "example": "Centro"
+                        },
+                        "isDefault": {
+                          "type": "boolean",
+                          "example": true
+                        }
+                      },
+                      "required": ["reference", "local"]
                     }
                   }
                 }
@@ -242,9 +282,13 @@
                 "schema": {
                   "type": "object",
                   "properties": {
-                    "message": {
-                      "type": "string",
-                      "example": "Perfil atualizado com sucesso"
+                    "id": { "type": "integer" },
+                    "username": { "type": "string" },
+                    "email": { "type": "string" },
+                    "role": { "type": "string" },
+                    "notificationTokens": {
+                      "type": "array",
+                      "items": { "type": "object" }
                     }
                   }
                 }
@@ -252,10 +296,57 @@
             }
           },
           "400": {
-            "description": "Erro de validação"
+            "description": "Erro de validação ou limite de endereços excedido",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string",
+                      "example": "Usuário pode ter no máximo 5 endereços"
+                    }
+                  }
+                }
+              }
+            }
           },
           "401": {
             "description": "Não autorizado"
+          }
+        }
+      }
+    },
+    "/users/addresses/{addressId}": {
+      "delete": {
+        "summary": "Remove um endereço do usuário",
+        "description": "Remove um endereço específico do usuário autenticado. O usuário só pode remover seus próprios endereços.",
+        "tags": ["Users"],
+        "security": [{ "bearerAuth": [] }],
+        "parameters": [
+          {
+            "name": "addressId",
+            "in": "path",
+            "required": true,
+            "description": "ID do endereço a ser removido",
+            "schema": {
+              "type": "integer",
+              "example": 123
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Endereço removido com sucesso"
+          },
+          "401": {
+            "description": "Não autorizado"
+          },
+          "404": {
+            "description": "Endereço não encontrado ou não pertence ao usuário"
+          },
+          "500": {
+            "description": "Erro interno do servidor"
           }
         }
       }

--- a/swagger.json
+++ b/swagger.json
@@ -213,8 +213,8 @@
         }
       },
       "put": {
-        "summary": "Atualiza o perfil do usuário autenticado",
-        "description": "Atualiza dados básicos e endereços do usuário. Endereços com ID são atualizados, sem ID são criados. Máximo 5 endereços por usuário.",
+        "summary": "Atualiza dados básicos do perfil do usuário",
+        "description": "Atualiza apenas dados básicos do usuário (username e telephone). Para gerenciar endereços, use os endpoints específicos de endereços.",
         "tags": ["Users"],
         "security": [{ "bearerAuth": [] }],
         "requestBody": {
@@ -233,41 +233,6 @@
                     "type": "string",
                     "pattern": "^[0-9]{11}$",
                     "example": "11987654321"
-                  },
-                  "addresses": {
-                    "type": "array",
-                    "maxItems": 5,
-                    "description": "Array de endereços. Endereços com ID são atualizados, sem ID são criados.",
-                    "items": {
-                      "type": "object",
-                      "properties": {
-                        "id": {
-                          "type": "integer",
-                          "description": "ID do endereço (opcional para novos endereços)"
-                        },
-                        "street": {
-                          "type": "string",
-                          "example": "Rua das Flores"
-                        },
-                        "number": {
-                          "type": "string",
-                          "example": "123"
-                        },
-                        "reference": {
-                          "type": "string",
-                          "example": "Próximo ao mercado"
-                        },
-                        "local": {
-                          "type": "string",
-                          "example": "Centro"
-                        },
-                        "isDefault": {
-                          "type": "boolean",
-                          "example": true
-                        }
-                      },
-                      "required": ["reference", "local"]
-                    }
                   }
                 }
               }
@@ -296,6 +261,83 @@
             }
           },
           "400": {
+            "description": "Erro de validação",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string",
+                      "example": "Campos não permitidos para atualização"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Não autorizado"
+          }
+        }
+      }
+    },
+    "/users/addresses": {
+      "post": {
+        "summary": "Cria um novo endereço para o usuário",
+        "description": "Cria um novo endereço para o usuário autenticado. Máximo de 5 endereços por usuário. O primeiro endereço é automaticamente definido como padrão.",
+        "tags": ["Users"],
+        "security": [{ "bearerAuth": [] }],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "street": {
+                    "type": "string",
+                    "example": "Rua das Flores"
+                  },
+                  "number": {
+                    "type": "string",
+                    "example": "123"
+                  },
+                  "reference": {
+                    "type": "string",
+                    "example": "Próximo ao mercado"
+                  },
+                  "local": {
+                    "type": "string",
+                    "example": "Centro"
+                  }
+                },
+                "required": ["reference", "local"]
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Endereço criado com sucesso",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "id": { "type": "integer" },
+                    "street": { "type": "string" },
+                    "number": { "type": "string" },
+                    "reference": { "type": "string" },
+                    "local": { "type": "string" },
+                    "user_id": { "type": "integer" },
+                    "isDefault": { "type": "boolean" }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
             "description": "Erro de validação ou limite de endereços excedido",
             "content": {
               "application/json": {
@@ -318,6 +360,99 @@
       }
     },
     "/users/addresses/{addressId}": {
+      "put": {
+        "summary": "Atualiza um endereço específico do usuário",
+        "description": "Atualiza um endereço específico do usuário autenticado. O usuário só pode atualizar seus próprios endereços.",
+        "tags": ["Users"],
+        "security": [{ "bearerAuth": [] }],
+        "parameters": [
+          {
+            "name": "addressId",
+            "in": "path",
+            "required": true,
+            "description": "ID do endereço a ser atualizado",
+            "schema": {
+              "type": "integer",
+              "example": 123
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "street": {
+                    "type": "string",
+                    "example": "Rua das Flores Atualizada"
+                  },
+                  "number": {
+                    "type": "string",
+                    "example": "456"
+                  },
+                  "reference": {
+                    "type": "string",
+                    "example": "Próximo ao shopping"
+                  },
+                  "local": {
+                    "type": "string",
+                    "example": "Centro"
+                  },
+                  "isDefault": {
+                    "type": "boolean",
+                    "example": true
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Endereço atualizado com sucesso",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "id": { "type": "integer" },
+                    "street": { "type": "string" },
+                    "number": { "type": "string" },
+                    "reference": { "type": "string" },
+                    "local": { "type": "string" },
+                    "user_id": { "type": "integer" },
+                    "isDefault": { "type": "boolean" }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Erro de validação"
+          },
+          "401": {
+            "description": "Não autorizado"
+          },
+          "404": {
+            "description": "Endereço não encontrado ou não pertence ao usuário",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string",
+                      "example": "Endereço não encontrado"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
       "delete": {
         "summary": "Remove um endereço do usuário",
         "description": "Remove um endereço específico do usuário autenticado. O usuário só pode remover seus próprios endereços.",


### PR DESCRIPTION
## 🚀 Funcionalidades

- **DELETE /users/addresses/:addressId** - Remover endereços específicos
- **PUT /users/profile** - Suporte a array de endereços (máx 5)
- **Validação de limite** - Máximo 5 endereços por usuário
- **Clean Code** - Refatoração seguindo princípios SOLID
- **Swagger atualizado** com novos endpoints e validações