### PR TITLE
feat: add metrics endpoints for orders and stock

### DIFF
--- a/src/modules/metrics/types.ts
+++ b/src/modules/metrics/types.ts
@@ -1,0 +1,14 @@
+export interface IDailyOrdersMetrics {
+  date: string;
+  ordersCount: number;
+  totalRevenue: number;
+  itemsByType: {
+    [type: string]: number;
+  };
+}
+
+export interface IStockMetrics {
+  [type: string]: {
+    totalQuantity: number;
+  };
+}

--- a/src/modules/metrics/useCases/getDailyOrdersMetrics/GetDailyOrdersMetricsController.ts
+++ b/src/modules/metrics/useCases/getDailyOrdersMetrics/GetDailyOrdersMetricsController.ts
@@ -1,0 +1,27 @@
+import { Request, Response } from "express";
+import { container } from "tsyringe";
+
+import { handleControllerError } from "@shared/utils/controller";
+
+import { GetDailyOrdersMetricsUseCase } from "./GetDailyOrdersMetricsUseCase";
+
+export class GetDailyOrdersMetricsController {
+  async handle(req: Request, res: Response): Promise<Response> {
+    try {
+      const getDailyOrdersMetricsUseCase = container.resolve(
+        GetDailyOrdersMetricsUseCase
+      );
+
+      const { date } = req.query;
+
+      const metrics = await getDailyOrdersMetricsUseCase.execute(
+        date as string | undefined
+      );
+
+      return res.status(200).json(metrics);
+    } catch (error) {
+      return handleControllerError(error, res);
+    }
+  }
+}
+

--- a/src/modules/metrics/useCases/getDailyOrdersMetrics/GetDailyOrdersMetricsController.ts
+++ b/src/modules/metrics/useCases/getDailyOrdersMetrics/GetDailyOrdersMetricsController.ts
@@ -24,4 +24,3 @@ export class GetDailyOrdersMetricsController {
     }
   }
 }
-

--- a/src/modules/metrics/useCases/getDailyOrdersMetrics/GetDailyOrdersMetricsUseCase.ts
+++ b/src/modules/metrics/useCases/getDailyOrdersMetrics/GetDailyOrdersMetricsUseCase.ts
@@ -1,0 +1,41 @@
+import dayjs from "@config/dayjs.config";
+import { IOrdersRepository } from "@modules/orders/repositories/IOrdersRepository";
+import { inject, injectable } from "tsyringe";
+
+import { IDailyOrdersMetrics } from "../../types";
+
+@injectable()
+export class GetDailyOrdersMetricsUseCase {
+  constructor(
+    @inject("OrdersRepository")
+    private ordersRepository: IOrdersRepository
+  ) {}
+
+  async execute(date?: string): Promise<IDailyOrdersMetrics> {
+    const targetDate = date ? dayjs(date).toDate() : dayjs().toDate();
+    const orders = await this.ordersRepository.findByDay(targetDate);
+
+    const itemsByType: { [type: string]: number } = {};
+    let totalRevenue = 0;
+
+    orders.forEach((order) => {
+      totalRevenue += order.total || 0;
+
+      if (order.orderItems) {
+        order.orderItems.forEach((item) => {
+          if (item.stock?.type) {
+            const { type } = item.stock;
+            itemsByType[type] = (itemsByType[type] || 0) + item.quantity;
+          }
+        });
+      }
+    });
+
+    return {
+      date: dayjs(targetDate).format("YYYY-MM-DD"),
+      ordersCount: orders.length,
+      totalRevenue,
+      itemsByType,
+    };
+  }
+}

--- a/src/modules/metrics/useCases/getStockMetrics/GetStockMetricsController.ts
+++ b/src/modules/metrics/useCases/getStockMetrics/GetStockMetricsController.ts
@@ -1,0 +1,25 @@
+import { Request, Response } from "express";
+import { container } from "tsyringe";
+
+import { handleControllerError } from "@shared/utils/controller";
+
+import { GetStockMetricsUseCase } from "./GetStockMetricsUseCase";
+
+export class GetStockMetricsController {
+  async handle(req: Request, res: Response): Promise<Response> {
+    try {
+      const getStockMetricsUseCase = container.resolve(GetStockMetricsUseCase);
+
+      const { type } = req.query;
+
+      const metrics = await getStockMetricsUseCase.execute(
+        type as string | undefined
+      );
+
+      return res.status(200).json(metrics);
+    } catch (error) {
+      return handleControllerError(error, res);
+    }
+  }
+}
+

--- a/src/modules/metrics/useCases/getStockMetrics/GetStockMetricsController.ts
+++ b/src/modules/metrics/useCases/getStockMetrics/GetStockMetricsController.ts
@@ -22,4 +22,3 @@ export class GetStockMetricsController {
     }
   }
 }
-

--- a/src/modules/metrics/useCases/getStockMetrics/GetStockMetricsUseCase.ts
+++ b/src/modules/metrics/useCases/getStockMetrics/GetStockMetricsUseCase.ts
@@ -1,0 +1,33 @@
+import { IStockRepository } from "@modules/stock/repositories/IStockRepository";
+import { inject, injectable } from "tsyringe";
+
+import { IStockMetrics } from "../../types";
+
+@injectable()
+export class GetStockMetricsUseCase {
+  constructor(
+    @inject("StockRepository")
+    private stockRepository: IStockRepository
+  ) {}
+
+  async execute(type?: string): Promise<IStockMetrics> {
+    const allStockItems = await this.stockRepository.findAll();
+
+    const metricsByType: IStockMetrics = {};
+
+    allStockItems.forEach((item) => {
+      if (type && item.type !== type) {
+        return;
+      }
+
+      if (!metricsByType[item.type]) {
+        metricsByType[item.type] = {
+          totalQuantity: 0,
+        };
+      }
+      metricsByType[item.type].totalQuantity += item.quantity;
+    });
+
+    return metricsByType;
+  }
+}

--- a/src/modules/orders/repositories/implementations/OrdersRepository.ts
+++ b/src/modules/orders/repositories/implementations/OrdersRepository.ts
@@ -1,3 +1,4 @@
+import dayjs from "@config/dayjs.config";
 import {
   ICreateOrderDTO,
   OrderProps,
@@ -6,7 +7,6 @@ import {
 
 import { prisma } from "@shared/infra/database/prisma";
 
-import dayjs from "../../../../config/dayjs.config";
 import { IOrdersRepository } from "../IOrdersRepository";
 
 export class OrdersRepository implements IOrdersRepository {
@@ -318,6 +318,11 @@ export class OrdersRepository implements IOrdersRepository {
           },
         },
         transactions: true,
+        orderItems: {
+          include: {
+            stock: true,
+          },
+        },
       },
       orderBy: {
         updated_at: "desc",

--- a/src/shared/containers/index.ts
+++ b/src/shared/containers/index.ts
@@ -17,6 +17,8 @@ import { SendNotificationUseCase } from "@modules/notifications/useCases/sendNot
 import { SendPaymentDueIn5DaysNotificationsUseCase } from "@modules/notifications/useCases/sendPaymentDueIn5DaysNotifications/sendPaymentDueIn5DaysNotificationsUseCase";
 import { SendPaymentDueTomorrowNotificationsUseCase } from "@modules/notifications/useCases/sendPaymentDueTomorrowNotifications/sendPaymentDueTomorrowNotificationsUseCase";
 import { SendPaymentLateNotificationsUseCase } from "@modules/notifications/useCases/sendPaymentLateNotifications/sendPaymentLateNotificationsUseCase";
+import { GetDailyOrdersMetricsUseCase } from "@modules/metrics/useCases/getDailyOrdersMetrics/GetDailyOrdersMetricsUseCase";
+import { GetStockMetricsUseCase } from "@modules/metrics/useCases/getStockMetrics/GetStockMetricsUseCase";
 import { OrdersRepository } from "@modules/orders/repositories/implementations/OrdersRepository";
 import { IOrdersRepository } from "@modules/orders/repositories/IOrdersRepository";
 import { IOrderCreationService } from "@modules/orders/services/IOrderCreationService";
@@ -99,3 +101,8 @@ container.registerSingleton<SendPaymentDueTomorrowNotificationsUseCase>(
 container.registerSingleton<SendPaymentLateNotificationsUseCase>(
   SendPaymentLateNotificationsUseCase
 );
+
+container.registerSingleton<GetDailyOrdersMetricsUseCase>(
+  GetDailyOrdersMetricsUseCase
+);
+container.registerSingleton<GetStockMetricsUseCase>(GetStockMetricsUseCase);

--- a/src/shared/containers/index.ts
+++ b/src/shared/containers/index.ts
@@ -6,6 +6,8 @@ import { IUserNotificationTokensRepository } from "@modules/accounts/repositorie
 import { IUsersRepository } from "@modules/accounts/repositories/interfaces/IUserRepository";
 import { IAddonsRepository } from "@modules/addons/repositories/IAddonsRepository";
 import { AddonsRepository } from "@modules/addons/repositories/implementations/AddonsRepository";
+import { GetDailyOrdersMetricsUseCase } from "@modules/metrics/useCases/getDailyOrdersMetrics/GetDailyOrdersMetricsUseCase";
+import { GetStockMetricsUseCase } from "@modules/metrics/useCases/getStockMetrics/GetStockMetricsUseCase";
 import { NotificationWorker } from "@modules/notifications/infra/queues/workers/NotificationWorker";
 import { NotificationHistoryRepository } from "@modules/notifications/repositories/implementations/NotificationHistoryRepository";
 import { ScheduledNotificationRepository } from "@modules/notifications/repositories/implementations/ScheduledNotificationRepository";
@@ -17,8 +19,6 @@ import { SendNotificationUseCase } from "@modules/notifications/useCases/sendNot
 import { SendPaymentDueIn5DaysNotificationsUseCase } from "@modules/notifications/useCases/sendPaymentDueIn5DaysNotifications/sendPaymentDueIn5DaysNotificationsUseCase";
 import { SendPaymentDueTomorrowNotificationsUseCase } from "@modules/notifications/useCases/sendPaymentDueTomorrowNotifications/sendPaymentDueTomorrowNotificationsUseCase";
 import { SendPaymentLateNotificationsUseCase } from "@modules/notifications/useCases/sendPaymentLateNotifications/sendPaymentLateNotificationsUseCase";
-import { GetDailyOrdersMetricsUseCase } from "@modules/metrics/useCases/getDailyOrdersMetrics/GetDailyOrdersMetricsUseCase";
-import { GetStockMetricsUseCase } from "@modules/metrics/useCases/getStockMetrics/GetStockMetricsUseCase";
 import { OrdersRepository } from "@modules/orders/repositories/implementations/OrdersRepository";
 import { IOrdersRepository } from "@modules/orders/repositories/IOrdersRepository";
 import { IOrderCreationService } from "@modules/orders/services/IOrderCreationService";

--- a/src/shared/infra/http/routes/index.ts
+++ b/src/shared/infra/http/routes/index.ts
@@ -2,6 +2,7 @@ import { Router } from "express";
 
 import { addonsRoutes } from "./addons.routes";
 import { authenticateRoutes } from "./authenticate.routes";
+import { metricsRoutes } from "./metrics.routes";
 import { notificationsRoutes } from "./notifications.routes";
 import { orderRoutes } from "./orders.routes";
 import { stockRoutes } from "./stock.routes";
@@ -17,5 +18,6 @@ router.use("/stock", stockRoutes);
 router.use("/addons", addonsRoutes);
 router.use("/transactions", transactionsRoutes);
 router.use("/notifications", notificationsRoutes);
+router.use("/metrics", metricsRoutes);
 
 export { router };

--- a/src/shared/infra/http/routes/metrics.routes.ts
+++ b/src/shared/infra/http/routes/metrics.routes.ts
@@ -1,0 +1,25 @@
+import { GetDailyOrdersMetricsController } from "@modules/metrics/useCases/getDailyOrdersMetrics/GetDailyOrdersMetricsController";
+import { GetStockMetricsController } from "@modules/metrics/useCases/getStockMetrics/GetStockMetricsController";
+import { Router } from "express";
+
+import { ensureAdmin } from "../middlewares/ensureAdmin";
+import { ensureAuthenticated } from "../middlewares/ensureAuthenticated";
+
+export const metricsRoutes = Router();
+
+const getDailyOrdersMetricsController = new GetDailyOrdersMetricsController();
+const getStockMetricsController = new GetStockMetricsController();
+
+metricsRoutes.get(
+  "/orders/daily",
+  ensureAuthenticated,
+  ensureAdmin,
+  getDailyOrdersMetricsController.handle
+);
+
+metricsRoutes.get(
+  "/stock",
+  ensureAuthenticated,
+  getStockMetricsController.handle
+);
+

--- a/src/shared/infra/http/routes/metrics.routes.ts
+++ b/src/shared/infra/http/routes/metrics.routes.ts
@@ -22,4 +22,3 @@ metricsRoutes.get(
   ensureAuthenticated,
   getStockMetricsController.handle
 );
-

--- a/swagger.json
+++ b/swagger.json
@@ -774,9 +774,7 @@
             "description": "Não autorizado"
           }
         }
-      }
-    },
-    "/stock": {
+      },
       "post": {
         "summary": "Cria um novo item de estoque",
         "tags": ["Stock"],
@@ -1132,6 +1130,78 @@
           }
         }
       }
+    },
+    "/metrics/orders/daily": {
+      "get": {
+        "summary": "Obtém métricas diárias de pedidos",
+        "tags": ["Metrics"],
+        "security": [{ "bearerAuth": [] }],
+        "parameters": [
+          {
+            "name": "date",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "format": "date",
+              "example": "2024-01-15"
+            },
+            "description": "Data no formato YYYY-MM-DD (padrão: hoje)"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Métricas diárias de pedidos retornadas com sucesso",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DailyOrdersMetrics"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Não autorizado"
+          },
+          "403": {
+            "description": "Requer admin"
+          }
+        }
+      }
+    },
+    "/metrics/stock": {
+      "get": {
+        "summary": "Obtém métricas de estoque",
+        "tags": ["Metrics"],
+        "security": [{ "bearerAuth": [] }],
+        "parameters": [
+          {
+            "name": "type",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "example": "WATER"
+            },
+            "description": "Tipo de estoque (WATER, GAS, etc). Se não fornecido, retorna todos os tipos"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Métricas de estoque retornadas com sucesso",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/StockMetrics"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Não autorizado"
+          }
+        }
+      }
     }
   },
   "components": {
@@ -1209,6 +1279,54 @@
           "id": { "type": "integer" },
           "name": { "type": "string" },
           "value": { "type": "number" }
+        }
+      },
+      "DailyOrdersMetrics": {
+        "type": "object",
+        "properties": {
+          "date": {
+            "type": "string",
+            "format": "date",
+            "example": "2024-01-15"
+          },
+          "ordersCount": {
+            "type": "integer",
+            "example": 10
+          },
+          "totalRevenue": {
+            "type": "number",
+            "example": 1500.50
+          },
+          "itemsByType": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "number"
+            },
+            "example": {
+              "WATER": 20,
+              "GAS": 15
+            }
+          }
+        }
+      },
+      "StockMetrics": {
+        "type": "object",
+        "additionalProperties": {
+          "type": "object",
+          "properties": {
+            "totalQuantity": {
+              "type": "integer",
+              "example": 100
+            }
+          }
+        },
+        "example": {
+          "WATER": {
+            "totalQuantity": 100
+          },
+          "GAS": {
+            "totalQuantity": 50
+          }
         }
       }
     }


### PR DESCRIPTION
Adiciona módulo de métricas com endpoints genéricos para dados agregados de pedidos e estoque.

## Endpoints criados
- GET /metrics/orders/daily?date=YYYY-MM-DD - Métricas diárias de pedidos (requer admin)
- GET /metrics/stock?type=WATER - Métricas de estoque (tipo opcional)

## Mudanças
- Criado módulo metrics com use cases para métricas de pedidos e estoque
- Endpoints retornam formato consistente seguindo padrões de Clean Code
- Documentação Swagger atualizada
- Registros no container de injeção de dependência

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new admin/authenticated API surface and changes order query includes for `findByDay`, which could affect performance and any callers relying on prior include shape.
> 
> **Overview**
> Adds a new `metrics` module and HTTP routes for aggregated reporting: `GET /metrics/orders/daily` (optionally filtered by `date`, admin-only) and `GET /metrics/stock` (optionally filtered by `type`).
> 
> Implements use cases to compute daily order counts/revenue and item quantities grouped by stock type, plus stock total quantities by type; wires them into DI container and Express routing, and updates Swagger schemas/docs accordingly. Also extends `OrdersRepository.findByDay` to include `orderItems` with `stock` data needed for the daily aggregation.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit abe815105d8c8da0343bb7bdd04cd64ac3769c22. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->