### PR TITLE
fix: sincroniza senhas MySQL na rotação de secrets

### DIFF
--- a/.github/actions/backup/action.yml
+++ b/.github/actions/backup/action.yml
@@ -14,6 +14,14 @@ inputs:
   vps-user:
     description: "VPS user"
     required: true
+  mysql-root-password:
+    description: "MySQL root password (preferred over .env on disk)"
+    required: false
+    default: ""
+  mysql-database:
+    description: "MySQL database name"
+    required: false
+    default: ""
 
 outputs:
   backup-file:
@@ -26,14 +34,22 @@ runs:
     - name: Create database backup
       id: backup
       shell: bash
+      env:
+        MYSQL_ROOT_PASSWORD: ${{ inputs.mysql-root-password }}
+        MYSQL_DATABASE: ${{ inputs.mysql-database }}
       run: |
         set -e
 
         echo "📦 Executando backup no ambiente: ${{ inputs.environment }}"
         echo ""
 
-        ssh -i ~/.ssh/id_rsa -o StrictHostKeyChecking=no ${{ inputs.vps-user }}@${{ inputs.vps-host }} \
-          "cd /home/deploy/gas-e-agua-backend && bash ./scripts/deploy/backup-db.sh ${{ inputs.environment }}"
+        ssh -i ~/.ssh/id_rsa -o StrictHostKeyChecking=no ${{ inputs.vps-user }}@${{ inputs.vps-host }} bash <<EOF
+        set -e
+        cd /home/deploy/gas-e-agua-backend
+        export MYSQL_ROOT_PASSWORD="$MYSQL_ROOT_PASSWORD"
+        export MYSQL_DATABASE="$MYSQL_DATABASE"
+        bash ./scripts/deploy/backup-db.sh ${{ inputs.environment }}
+        EOF
 
         echo ""
         echo "✅ Backup concluído com sucesso!"

--- a/.github/workflows/backup.yml
+++ b/.github/workflows/backup.yml
@@ -35,14 +35,29 @@ jobs:
           VPS_USER: ${{ secrets.VPS_USER }}
           VPS_HOST: ${{ secrets.VPS_HOST }}
           ENVIRONMENT: ${{ github.event.inputs.environment || 'dev' }}
+          MYSQL_ROOT_PASSWORD_DEV: ${{ secrets.MYSQL_ROOT_PASSWORD_DEV }}
+          MYSQL_ROOT_PASSWORD_PRD: ${{ secrets.MYSQL_ROOT_PASSWORD_PRD }}
         run: |
           echo "📦 Iniciando backup no ambiente: ${ENVIRONMENT}"
           echo "🔗 Conectando em ${VPS_USER}@${VPS_HOST}..."
           echo ""
 
+          if [ "$ENVIRONMENT" = "prd" ]; then
+            MYSQL_ROOT_PASSWORD="$MYSQL_ROOT_PASSWORD_PRD"
+            MYSQL_DATABASE="gas_e_agua"
+          else
+            MYSQL_ROOT_PASSWORD="$MYSQL_ROOT_PASSWORD_DEV"
+            MYSQL_DATABASE="gas_e_agua_dev"
+          fi
+
           # Executa o backup e mostra output em tempo real
-          ssh -i ~/.ssh/id_rsa -o StrictHostKeyChecking=no -o ConnectTimeout=30 ${VPS_USER}@${VPS_HOST} \
-            "cd /home/deploy/gas-e-agua-backend && bash ./scripts/deploy/backup-db.sh ${ENVIRONMENT}" | tee /tmp/backup_output.txt
+          ssh -i ~/.ssh/id_rsa -o StrictHostKeyChecking=no -o ConnectTimeout=30 ${VPS_USER}@${VPS_HOST} bash <<EOF | tee /tmp/backup_output.txt
+          set -e
+          cd /home/deploy/gas-e-agua-backend
+          export MYSQL_ROOT_PASSWORD="$MYSQL_ROOT_PASSWORD"
+          export MYSQL_DATABASE="$MYSQL_DATABASE"
+          bash ./scripts/deploy/backup-db.sh ${ENVIRONMENT}
+          EOF
 
           SSH_EXIT_CODE=${PIPESTATUS[0]}
 

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -46,6 +46,7 @@ jobs:
           scp -i ~/.ssh/id_rsa -o StrictHostKeyChecking=no \
             scripts/deploy/deploy.sh \
             scripts/deploy/backup-db.sh \
+            scripts/deploy/sync-mysql-credentials.sh \
             scripts/deploy/rollback.sh \
             scripts/deploy/cleanup-old-versions.sh \
             ${{ secrets.VPS_USER }}@${{ secrets.VPS_HOST }}:/home/deploy/gas-e-agua-backend/scripts/deploy/
@@ -69,6 +70,8 @@ jobs:
           ssh-key: ${{ secrets.SSH_PRIVATE_KEY }}
           vps-host: ${{ secrets.VPS_HOST }}
           vps-user: ${{ secrets.VPS_USER }}
+          mysql-root-password: ${{ secrets.MYSQL_ROOT_PASSWORD_DEV }}
+          mysql-database: gas_e_agua_dev
 
       # Etapa 4: Deploy da aplicação (login GHCR, .env temporário, script deploy.sh na VPS)
       - name: Deploy application

--- a/.github/workflows/deploy-prd.yml
+++ b/.github/workflows/deploy-prd.yml
@@ -47,6 +47,7 @@ jobs:
           scp -i ~/.ssh/id_rsa -o StrictHostKeyChecking=no \
             scripts/deploy/deploy.sh \
             scripts/deploy/backup-db.sh \
+            scripts/deploy/sync-mysql-credentials.sh \
             scripts/deploy/rollback.sh \
             scripts/deploy/cleanup-old-versions.sh \
             ${{ secrets.VPS_USER }}@${{ secrets.VPS_HOST }}:/home/deploy/gas-e-agua-backend/scripts/deploy/
@@ -70,6 +71,8 @@ jobs:
           ssh-key: ${{ secrets.SSH_PRIVATE_KEY }}
           vps-host: ${{ secrets.VPS_HOST }}
           vps-user: ${{ secrets.VPS_USER }}
+          mysql-root-password: ${{ secrets.MYSQL_ROOT_PASSWORD_PRD }}
+          mysql-database: gas_e_agua
 
       # Etapa 4: Deploy em PRODUÇÃO (login GHCR, .env temporário, script deploy.sh na VPS)
       - name: Deploy application

--- a/.github/workflows/rotate-secrets.yml
+++ b/.github/workflows/rotate-secrets.yml
@@ -62,6 +62,42 @@ jobs:
           echo "✅ Secrets generated successfully"
           echo "::endgroup::"
 
+      - name: Setup SSH
+        run: |
+          mkdir -p ~/.ssh
+          echo "${{ secrets.SSH_PRIVATE_KEY }}" > ~/.ssh/id_rsa
+          chmod 600 ~/.ssh/id_rsa
+          ssh-keyscan -H ${{ secrets.VPS_HOST }} >> ~/.ssh/known_hosts
+
+      - name: Sync MySQL credentials on VPS (before updating GitHub secrets)
+        env:
+          MYSQL_ROOT_PASSWORD_CURRENT: ${{ secrets.MYSQL_ROOT_PASSWORD_DEV }}
+          MYSQL_ROOT_PASSWORD_NEW: ${{ steps.generate.outputs.mysql_root_password }}
+          MYSQL_PASSWORD_NEW: ${{ steps.generate.outputs.mysql_password }}
+        run: |
+          echo "::group::🔐 Syncing MySQL credentials on DEV VPS"
+
+          scp -i ~/.ssh/id_rsa -o StrictHostKeyChecking=no \
+            scripts/deploy/sync-mysql-credentials.sh \
+            ${{ secrets.VPS_USER }}@${{ secrets.VPS_HOST }}:/home/deploy/gas-e-agua-backend/scripts/deploy/
+
+          ssh -i ~/.ssh/id_rsa -o StrictHostKeyChecking=no ${{ secrets.VPS_USER }}@${{ secrets.VPS_HOST }} \
+            "chmod +x /home/deploy/gas-e-agua-backend/scripts/deploy/sync-mysql-credentials.sh"
+
+          ssh -i ~/.ssh/id_rsa -o StrictHostKeyChecking=no ${{ secrets.VPS_USER }}@${{ secrets.VPS_HOST }} bash <<EOF
+          set -e
+          cd /home/deploy/gas-e-agua-backend
+          export MYSQL_ROOT_PASSWORD_CURRENT="$MYSQL_ROOT_PASSWORD_CURRENT"
+          export MYSQL_ROOT_PASSWORD_NEW="$MYSQL_ROOT_PASSWORD_NEW"
+          export MYSQL_PASSWORD_NEW="$MYSQL_PASSWORD_NEW"
+          export MYSQL_USER="gas_e_agua_dev"
+          export MYSQL_DATABASE="gas_e_agua_dev"
+          bash ./scripts/deploy/sync-mysql-credentials.sh dev
+          EOF
+
+          echo "✅ MySQL credentials synced on DEV"
+          echo "::endgroup::"
+
       - name: Update GitHub Secrets
         env:
           GH_TOKEN: ${{ secrets.GHCR_TOKEN }}
@@ -143,7 +179,7 @@ jobs:
                     <h3>⚠️ Important Information:</h3>
                     <ul>
                       <li><span class="icon">📝</span> <strong>JWT_SECRET:</strong> All active user sessions have been invalidated. Users will need to log in again.</li>
-                      <li><span class="icon">🗄️</span> <strong>MySQL Password:</strong> Automatically updated in the database via deploy script.</li>
+                      <li><span class="icon">🗄️</span> <strong>MySQL Password:</strong> Updated inside MySQL on the VPS before GitHub secrets were changed.</li>
                       <li><span class="icon">🚀</span> <strong>Deploy:</strong> Automatically triggered to apply new secrets.</li>
                     </ul>
                   </div>
@@ -200,6 +236,42 @@ jobs:
           echo "grafana_secret_key=$GRAFANA_SECRET_KEY" >> $GITHUB_OUTPUT
 
           echo "✅ Secrets generated successfully"
+          echo "::endgroup::"
+
+      - name: Setup SSH
+        run: |
+          mkdir -p ~/.ssh
+          echo "${{ secrets.SSH_PRIVATE_KEY }}" > ~/.ssh/id_rsa
+          chmod 600 ~/.ssh/id_rsa
+          ssh-keyscan -H ${{ secrets.VPS_HOST }} >> ~/.ssh/known_hosts
+
+      - name: Sync MySQL credentials on VPS (before updating GitHub secrets)
+        env:
+          MYSQL_ROOT_PASSWORD_CURRENT: ${{ secrets.MYSQL_ROOT_PASSWORD_PRD }}
+          MYSQL_ROOT_PASSWORD_NEW: ${{ steps.generate.outputs.mysql_root_password }}
+          MYSQL_PASSWORD_NEW: ${{ steps.generate.outputs.mysql_password }}
+        run: |
+          echo "::group::🔐 Syncing MySQL credentials on PRD VPS"
+
+          scp -i ~/.ssh/id_rsa -o StrictHostKeyChecking=no \
+            scripts/deploy/sync-mysql-credentials.sh \
+            ${{ secrets.VPS_USER }}@${{ secrets.VPS_HOST }}:/home/deploy/gas-e-agua-backend/scripts/deploy/
+
+          ssh -i ~/.ssh/id_rsa -o StrictHostKeyChecking=no ${{ secrets.VPS_USER }}@${{ secrets.VPS_HOST }} \
+            "chmod +x /home/deploy/gas-e-agua-backend/scripts/deploy/sync-mysql-credentials.sh"
+
+          ssh -i ~/.ssh/id_rsa -o StrictHostKeyChecking=no ${{ secrets.VPS_USER }}@${{ secrets.VPS_HOST }} bash <<EOF
+          set -e
+          cd /home/deploy/gas-e-agua-backend
+          export MYSQL_ROOT_PASSWORD_CURRENT="$MYSQL_ROOT_PASSWORD_CURRENT"
+          export MYSQL_ROOT_PASSWORD_NEW="$MYSQL_ROOT_PASSWORD_NEW"
+          export MYSQL_PASSWORD_NEW="$MYSQL_PASSWORD_NEW"
+          export MYSQL_USER="gas_e_agua"
+          export MYSQL_DATABASE="gas_e_agua"
+          bash ./scripts/deploy/sync-mysql-credentials.sh prd
+          EOF
+
+          echo "✅ MySQL credentials synced on PRD"
           echo "::endgroup::"
 
       - name: Update GitHub Secrets
@@ -292,7 +364,7 @@ jobs:
                   <div class="alert">
                     <h3>📝 Automatic Actions:</h3>
                     <ul>
-                      <li><span class="icon">🗄️</span> MySQL password automatically updated in database</li>
+                      <li><span class="icon">🗄️</span> MySQL password updated inside the database on the VPS before GitHub secrets were changed</li>
                       <li><span class="icon">🚀</span> Deploy triggered to apply new secrets</li>
                       <li><span class="icon">📊</span> Grafana admin password updated</li>
                     </ul>

--- a/scripts/deploy/backup-db.sh
+++ b/scripts/deploy/backup-db.sh
@@ -34,20 +34,25 @@ else
   exit 1
 fi
 
-if [ ! -f "$ENV_FILE" ]; then
+if [ -n "${MYSQL_ROOT_PASSWORD:-}" ] && [ -n "${MYSQL_DATABASE:-}" ]; then
+  echo "📄 Credenciais carregadas das variáveis de ambiente"
+elif [ -f "$ENV_FILE" ]; then
+  # shellcheck disable=SC1090
+  source "$ENV_FILE"
+  echo "📄 Credenciais carregadas de: $ENV_FILE"
+else
   echo "❌ Arquivo de ambiente não encontrado: $ENV_FILE"
+  echo "   E MYSQL_ROOT_PASSWORD/MYSQL_DATABASE também não estão definidos no ambiente"
   exit 1
 fi
 
-source "$ENV_FILE"
-
-if [ -z "$MYSQL_DATABASE" ]; then
-  echo "❌ MYSQL_DATABASE não encontrado no arquivo $ENV_FILE"
+if [ -z "${MYSQL_DATABASE:-}" ]; then
+  echo "❌ MYSQL_DATABASE não encontrado"
   exit 1
 fi
 
-if [ -z "$MYSQL_ROOT_PASSWORD" ]; then
-  echo "❌ MYSQL_ROOT_PASSWORD não encontrado no arquivo $ENV_FILE"
+if [ -z "${MYSQL_ROOT_PASSWORD:-}" ]; then
+  echo "❌ MYSQL_ROOT_PASSWORD não encontrado"
   exit 1
 fi
 

--- a/scripts/deploy/deploy.sh
+++ b/scripts/deploy/deploy.sh
@@ -190,6 +190,9 @@ log_info "Checking user: $MYSQL_USER"
 log_info "Database: $MYSQL_DATABASE"
 
 if docker compose -p "$PROJECT" -f "$COMPOSE_FILE" exec -T mysql mysql -uroot -p"${MYSQL_ROOT_PASSWORD}" <<-EOSQL 2>/dev/null || true
+  ALTER USER 'root'@'localhost' IDENTIFIED WITH mysql_native_password BY '${MYSQL_ROOT_PASSWORD}';
+  CREATE USER IF NOT EXISTS 'root'@'%' IDENTIFIED WITH mysql_native_password BY '${MYSQL_ROOT_PASSWORD}';
+  ALTER USER 'root'@'%' IDENTIFIED WITH mysql_native_password BY '${MYSQL_ROOT_PASSWORD}';
   ALTER USER IF EXISTS '${MYSQL_USER}'@'%' IDENTIFIED WITH mysql_native_password BY '${MYSQL_PASSWORD}';
   CREATE USER IF NOT EXISTS '${MYSQL_USER}'@'%' IDENTIFIED WITH mysql_native_password BY '${MYSQL_PASSWORD}';
   GRANT ALL PRIVILEGES ON \`${MYSQL_DATABASE}\`.* TO '${MYSQL_USER}'@'%';

--- a/scripts/deploy/sync-mysql-credentials.sh
+++ b/scripts/deploy/sync-mysql-credentials.sh
@@ -1,0 +1,92 @@
+#!/bin/bash
+
+set -euo pipefail
+
+ENV=${1:-}
+
+if [ -z "$ENV" ]; then
+  echo "Uso: $0 [dev|prd]"
+  echo "Variáveis obrigatórias:"
+  echo "  MYSQL_ROOT_PASSWORD_CURRENT  senha root atual no MySQL"
+  echo "  MYSQL_ROOT_PASSWORD_NEW      nova senha root"
+  echo "  MYSQL_PASSWORD_NEW           nova senha do usuário da aplicação"
+  echo "  MYSQL_USER                   usuário da aplicação"
+  echo "  MYSQL_DATABASE               nome do banco"
+  exit 1
+fi
+
+if [ "$ENV" = "dev" ]; then
+  MYSQL_CONTAINER="gas-e-agua-mysql-dev"
+elif [ "$ENV" = "prd" ]; then
+  MYSQL_CONTAINER="gas-e-agua-mysql"
+else
+  echo "❌ Ambiente inválido: $ENV (use dev ou prd)"
+  exit 1
+fi
+
+required_variables=(
+  MYSQL_ROOT_PASSWORD_CURRENT
+  MYSQL_ROOT_PASSWORD_NEW
+  MYSQL_PASSWORD_NEW
+  MYSQL_USER
+  MYSQL_DATABASE
+)
+
+for variable_name in "${required_variables[@]}"; do
+  if [ -z "${!variable_name:-}" ]; then
+    echo "❌ Variável obrigatória ausente: $variable_name"
+    exit 1
+  fi
+done
+
+escape_sql_literal() {
+  printf "%s" "$1" | sed "s/'/''/g"
+}
+
+escaped_root_password_new=$(escape_sql_literal "$MYSQL_ROOT_PASSWORD_NEW")
+escaped_app_password_new=$(escape_sql_literal "$MYSQL_PASSWORD_NEW")
+escaped_mysql_user=$(escape_sql_literal "$MYSQL_USER")
+escaped_mysql_database=$(escape_sql_literal "$MYSQL_DATABASE")
+
+if ! docker ps --format '{{.Names}}' | grep -qx "$MYSQL_CONTAINER"; then
+  echo "❌ Container $MYSQL_CONTAINER não está em execução"
+  exit 1
+fi
+
+echo "🔐 Sincronizando credenciais MySQL no ambiente: $ENV"
+echo "   Container: $MYSQL_CONTAINER"
+echo "   Usuário app: $MYSQL_USER"
+echo "   Database: $MYSQL_DATABASE"
+
+echo "🔌 Validando senha root atual..."
+if ! docker exec "$MYSQL_CONTAINER" mysql \
+  --user=root \
+  --password="$MYSQL_ROOT_PASSWORD_CURRENT" \
+  -e "SELECT 1;" > /dev/null 2>&1; then
+  echo "❌ Senha root atual inválida para $MYSQL_CONTAINER"
+  exit 1
+fi
+
+echo "📤 Aplicando novas senhas (root + usuário da app)..."
+docker exec -i "$MYSQL_CONTAINER" mysql \
+  --user=root \
+  --password="$MYSQL_ROOT_PASSWORD_CURRENT" <<SQL
+ALTER USER 'root'@'localhost' IDENTIFIED WITH mysql_native_password BY '${escaped_root_password_new}';
+CREATE USER IF NOT EXISTS 'root'@'%' IDENTIFIED WITH mysql_native_password BY '${escaped_root_password_new}';
+ALTER USER 'root'@'%' IDENTIFIED WITH mysql_native_password BY '${escaped_root_password_new}';
+ALTER USER IF EXISTS '${escaped_mysql_user}'@'%' IDENTIFIED WITH mysql_native_password BY '${escaped_app_password_new}';
+CREATE USER IF NOT EXISTS '${escaped_mysql_user}'@'%' IDENTIFIED WITH mysql_native_password BY '${escaped_app_password_new}';
+GRANT ALL PRIVILEGES ON \`${escaped_mysql_database}\`.* TO '${escaped_mysql_user}'@'%';
+FLUSH PRIVILEGES;
+SQL
+
+echo "🔌 Validando nova senha root..."
+if ! docker exec "$MYSQL_CONTAINER" mysql \
+  --user=root \
+  --password="$MYSQL_ROOT_PASSWORD_NEW" \
+  -e "USE \`${MYSQL_DATABASE}\`; SELECT 1;" > /dev/null 2>&1; then
+  echo "❌ Falha ao validar nova senha root após sync"
+  exit 1
+fi
+
+echo "✅ Credenciais MySQL sincronizadas com sucesso"


### PR DESCRIPTION
## Summary
- Sincroniza as senhas do MySQL no VPS **antes** de atualizar os GitHub Secrets na rotação trimestral, evitando desalinhamento com o volume Docker
- Faz o backup de deploy/agendado usar credenciais do Actions em vez de depender de `.env` no disco
- Alinha também a senha do `root` no `deploy.sh` e adiciona `sync-mysql-credentials.sh`

## Test plan
- [ ] Revisar o fluxo em `rotate-secrets.yml` (sync VPS → update secrets → deploy)
- [ ] Re-rodar **Deploy to VPS (DEV)** e confirmar que o step de backup passa
- [ ] Confirmar no VPS: `SHOW DATABASES` com a senha atual do secret DEV
- [ ] (Opcional) dry-run mental do próximo rotate: senha antiga ainda válida no MySQL no momento do sync