### PR TITLE
fix: adiciona coluna type em OrderItems e OrderAddons

### DIFF
--- a/prisma/migrations/20260812200800_add_type_on_order_items_and_addons/migration.sql
+++ b/prisma/migrations/20260812200800_add_type_on_order_items_and_addons/migration.sql
@@ -1,0 +1,36 @@
+-- Add denormalized `type` on OrderItems and OrderAddons (already in schema.prisma).
+-- Backfill from Stock/Addons so existing rows remain valid.
+
+SELECT IF(
+  COUNT(*) = 0,
+  'ALTER TABLE `OrderItems` ADD COLUMN `type` VARCHAR(191) NULL',
+  'SELECT "Column OrderItems.type already exists"'
+) INTO @sql FROM information_schema.columns
+WHERE table_schema = DATABASE() AND table_name = 'OrderItems' AND column_name = 'type';
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+
+UPDATE `OrderItems` oi
+INNER JOIN `Stock` s ON oi.stockId = s.id
+SET oi.type = s.type
+WHERE oi.type IS NULL OR oi.type = '';
+
+UPDATE `OrderItems` SET `type` = '' WHERE `type` IS NULL;
+
+ALTER TABLE `OrderItems` MODIFY `type` VARCHAR(191) NOT NULL;
+
+SELECT IF(
+  COUNT(*) = 0,
+  'ALTER TABLE `OrderAddons` ADD COLUMN `type` VARCHAR(191) NULL',
+  'SELECT "Column OrderAddons.type already exists"'
+) INTO @sql FROM information_schema.columns
+WHERE table_schema = DATABASE() AND table_name = 'OrderAddons' AND column_name = 'type';
+PREPARE stmt FROM @sql; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+
+UPDATE `OrderAddons` oa
+INNER JOIN `Addons` a ON oa.addonId = a.id
+SET oa.type = a.type
+WHERE oa.type IS NULL OR oa.type = '';
+
+UPDATE `OrderAddons` SET `type` = '' WHERE `type` IS NULL;
+
+ALTER TABLE `OrderAddons` MODIFY `type` VARCHAR(191) NOT NULL;


### PR DESCRIPTION
## Summary
- Corrige o 500 ao visualizar pedido no DEV (`OrderItems.type` / `OrderAddons.type` ausentes no banco).
- Migration idempotente: cria as colunas, preenche a partir de `Stock`/`Addons` e aplica `NOT NULL`.

## Test plan
- [ ] Merge em `develop` e aguardar o deploy DEV aplicar `prisma migrate deploy`
- [ ] Abrir um pedido existente no app (`GET /orders/:id`) e confirmar 200
- [ ] Confirmar que itens e adicionais continuam com o `type` correto