### PR TITLE
fix: coleta logs Winston da API no Promtail para o Grafana

### DIFF
--- a/monitoring/promtail/promtail-config.yml
+++ b/monitoring/promtail/promtail-config.yml
@@ -9,12 +9,36 @@ clients:
   - url: http://loki:3100/loki/api/v1/push
 
 scrape_configs:
-  # Logs de containers Docker
+  # Winston JSON (combined.log já inclui error; não raspar error.log para evitar duplicata)
+  - job_name: gas-e-agua-app-files
+    static_configs:
+      - targets:
+          - localhost
+        labels:
+          job: gas-e-agua-backend
+          __path__: /var/log/app/combined.log
+    pipeline_stages:
+      - json:
+          expressions:
+            level: level
+            type: type
+            timestamp: timestamp
+      - timestamp:
+          source: timestamp
+          format: RFC3339
+      - labels:
+          level:
+          type:
+
+  # Stdout do container da API (crash/npm). Job separado para não duplicar no Grafana.
   - job_name: docker
     docker_sd_configs:
       - host: unix:///var/run/docker.sock
         refresh_interval: 5s
     relabel_configs:
+      - source_labels: ["__meta_docker_container_name"]
+        regex: "/gas-e-agua-app.*"
+        action: keep
       - source_labels: ["__meta_docker_container_name"]
         regex: "/(.+)"
         target_label: "container_name"
@@ -22,18 +46,10 @@ scrape_configs:
       - source_labels: ["__meta_docker_container_log_stream"]
         target_label: "stream"
       - source_labels: ["__meta_docker_container_name"]
-        regex: "gas-e-agua-app.*"
+        regex: "/gas-e-agua-app.*"
         target_label: "job"
-        replacement: "gas-e-agua-backend"
+        replacement: "gas-e-agua-backend-stdout"
     pipeline_stages:
-      - json:
-          expressions:
-            message: log
-            stream: stream
-            time: time
-      - timestamp:
-          source: time
-          format: RFC3339Nano
       - labels:
           container_name:
           stream:


### PR DESCRIPTION
## Summary
- Faz o Promtail raspar `combined.log` (Winston JSON) com `job=gas-e-agua-backend`, que é o filtro do dashboard no Grafana.
- Corrige o regex do scrape Docker (`/gas-e-agua-app.*`) e restringe ao container da API.
- Envia stdout do container para um job separado, para não duplicar logs no Grafana.

## Test plan
- [ ] Reiniciar o Promtail em DEV (`docker restart promtail-dev` ou `docker compose -f docker-compose.monitoring-dev.yml up -d promtail`)
- [ ] Gerar um erro na API de DEV
- [ ] Conferir o dashboard "Gas e Água Backend - Logs" no Grafana (`{job="gas-e-agua-backend"}`)
- [ ] Confirmar que o painel de erros (`level = "error"`) lista o log JSON