### PR TITLE
fix: contar pagamentos manuais no faturamento do admin

### DIFF
--- a/src/modules/metrics/useCases/getRevenueMetrics/GetRevenueMetricsUseCase.test.ts
+++ b/src/modules/metrics/useCases/getRevenueMetrics/GetRevenueMetricsUseCase.test.ts
@@ -131,4 +131,17 @@ describe(GetRevenueMetricsUseCase.name, () => {
     ).not.toHaveBeenCalled();
     expect(ordersRepository.findAllOrdersByDateRange).not.toHaveBeenCalled();
   });
+
+  it("should use America/Recife day boundaries for payment range", async () => {
+    transactionsRepository.sumPaymentsByDateRange.mockResolvedValue(80);
+    ordersRepository.findAllOrdersByDateRange.mockResolvedValue([]);
+
+    await getRevenueMetricsUseCase.execute("2026-08-20", "2026-08-20");
+
+    const [rangeStart, rangeEndExclusive] =
+      transactionsRepository.sumPaymentsByDateRange.mock.calls[0];
+
+    expect(rangeStart.toISOString()).toBe("2026-08-20T03:00:00.000Z");
+    expect(rangeEndExclusive.toISOString()).toBe("2026-08-21T03:00:00.000Z");
+  });
 });

--- a/src/modules/metrics/useCases/getRevenueMetrics/GetRevenueMetricsUseCase.ts
+++ b/src/modules/metrics/useCases/getRevenueMetrics/GetRevenueMetricsUseCase.ts
@@ -8,6 +8,8 @@ import { AppError } from "@shared/errors/AppError";
 
 import { IRevenueMetrics } from "../../types";
 
+const BUSINESS_TIMEZONE = "America/Recife";
+
 @injectable()
 export class GetRevenueMetricsUseCase {
   constructor(
@@ -21,13 +23,8 @@ export class GetRevenueMetricsUseCase {
     startDateParam?: string,
     endDateParam?: string
   ): Promise<IRevenueMetrics> {
-    const startDate = startDateParam
-      ? dayjs(startDateParam).startOf("day")
-      : dayjs().startOf("day");
-
-    const endDate = endDateParam
-      ? dayjs(endDateParam).endOf("day")
-      : dayjs(startDate).endOf("day");
+    const startDate = this.resolveBusinessDayStart(startDateParam);
+    const endDate = this.resolveBusinessDayEnd(endDateParam, startDate);
 
     const isStartDateInvalid = !startDate.isValid();
     const isEndDateInvalid = !endDate.isValid();
@@ -48,7 +45,9 @@ export class GetRevenueMetricsUseCase {
       });
     }
 
-    const endDateExclusive = dayjs(endDateValue).add(1, "millisecond").toDate();
+    const formattedStartDate = startDate.format("YYYY-MM-DD");
+    const formattedEndDate = endDate.format("YYYY-MM-DD");
+    const endDateExclusive = endDate.clone().add(1, "millisecond").toDate();
 
     const [paidRevenue, ordersInRange] = await Promise.all([
       this.transactionsRepository.sumPaymentsByDateRange(
@@ -65,13 +64,46 @@ export class GetRevenueMetricsUseCase {
     const itemsByType = this.countItemsByType(ordersInRange);
 
     return {
-      startDate: startDate.format("YYYY-MM-DD"),
-      endDate: endDate.format("YYYY-MM-DD"),
+      startDate: formattedStartDate,
+      endDate: formattedEndDate,
       ordersCount: ordersInRange.length,
       paidRevenue,
       pendingRevenue,
       itemsByType,
     };
+  }
+
+  private resolveBusinessDayStart(startDateParam?: string) {
+    if (!startDateParam) {
+      return dayjs().tz(BUSINESS_TIMEZONE).startOf("day");
+    }
+
+    const parsedStartDate = dayjs(startDateParam);
+    if (!parsedStartDate.isValid()) {
+      return parsedStartDate;
+    }
+
+    return dayjs
+      .tz(parsedStartDate.format("YYYY-MM-DD"), BUSINESS_TIMEZONE)
+      .startOf("day");
+  }
+
+  private resolveBusinessDayEnd(
+    endDateParam: string | undefined,
+    startDate: dayjs.Dayjs
+  ) {
+    if (!endDateParam) {
+      return startDate.clone().endOf("day");
+    }
+
+    const parsedEndDate = dayjs(endDateParam);
+    if (!parsedEndDate.isValid()) {
+      return parsedEndDate;
+    }
+
+    return dayjs
+      .tz(parsedEndDate.format("YYYY-MM-DD"), BUSINESS_TIMEZONE)
+      .endOf("day");
   }
 
   private calculatePendingRevenue(orders: OrderProps[]): number {

--- a/src/modules/orders/useCases/getAdminHomeDashboard/GetAdminHomeDashboardUseCase.test.ts
+++ b/src/modules/orders/useCases/getAdminHomeDashboard/GetAdminHomeDashboardUseCase.test.ts
@@ -11,6 +11,9 @@ describe("GetAdminHomeDashboardUseCase", () => {
   let stockRepository: {
     findAll: jest.Mock;
   };
+  let transactionsRepository: {
+    sumPaymentsByDateRange: jest.Mock;
+  };
 
   beforeEach(() => {
     ordersRepository = {
@@ -21,9 +24,14 @@ describe("GetAdminHomeDashboardUseCase", () => {
       findAll: jest.fn(),
     };
 
+    transactionsRepository = {
+      sumPaymentsByDateRange: jest.fn(),
+    };
+
     getAdminHomeDashboardUseCase = new GetAdminHomeDashboardUseCase(
       ordersRepository as any,
-      stockRepository as any
+      stockRepository as any,
+      transactionsRepository as any
     );
   });
 
@@ -36,7 +44,7 @@ describe("GetAdminHomeDashboardUseCase", () => {
         payment_state: "PAGO",
         updated_at: new Date().toISOString(),
         created_at: new Date().toISOString(),
-        total: 100,
+        total: 0,
         interest_allowed: true,
         orderItems: [
           {
@@ -74,7 +82,7 @@ describe("GetAdminHomeDashboardUseCase", () => {
         payment_state: "PAGO",
         updated_at: new Date().toISOString(),
         created_at: new Date().toISOString(),
-        total: 50,
+        total: 0,
         interest_allowed: true,
         orderItems: [
           {
@@ -121,11 +129,16 @@ describe("GetAdminHomeDashboardUseCase", () => {
 
     ordersRepository.findByDay.mockResolvedValue(todayOrders);
     stockRepository.findAll.mockResolvedValue(stockItems);
+    transactionsRepository.sumPaymentsByDateRange.mockResolvedValue(150);
 
     const result = await getAdminHomeDashboardUseCase.execute();
 
     expect(ordersRepository.findByDay).toHaveBeenCalledWith(expect.any(Date));
     expect(stockRepository.findAll).toHaveBeenCalled();
+    expect(transactionsRepository.sumPaymentsByDateRange).toHaveBeenCalledWith(
+      expect.any(Date),
+      expect.any(Date)
+    );
     expect(result).toEqual({
       totalOrdersToday: 2,
       waterOrdersToday: 2,
@@ -139,6 +152,7 @@ describe("GetAdminHomeDashboardUseCase", () => {
   it("should return zero values when there are no orders or stock items", async () => {
     ordersRepository.findByDay.mockResolvedValue([]);
     stockRepository.findAll.mockResolvedValue([]);
+    transactionsRepository.sumPaymentsByDateRange.mockResolvedValue(0);
 
     const result = await getAdminHomeDashboardUseCase.execute();
 
@@ -152,7 +166,7 @@ describe("GetAdminHomeDashboardUseCase", () => {
     });
   });
 
-  it("should include only paid orders in totalRevenueToday", async () => {
+  it("should use payment transactions for totalRevenueToday instead of order.total", async () => {
     const todayOrders: OrderProps[] = [
       {
         id: 1,
@@ -161,7 +175,7 @@ describe("GetAdminHomeDashboardUseCase", () => {
         payment_state: "PAGO",
         updated_at: new Date().toISOString(),
         created_at: new Date().toISOString(),
-        total: 100,
+        total: 0,
         interest_allowed: true,
         address: {
           id: 1,
@@ -194,10 +208,12 @@ describe("GetAdminHomeDashboardUseCase", () => {
 
     ordersRepository.findByDay.mockResolvedValue(todayOrders);
     stockRepository.findAll.mockResolvedValue([]);
+    transactionsRepository.sumPaymentsByDateRange.mockResolvedValue(100);
 
     const result = await getAdminHomeDashboardUseCase.execute();
 
     expect(result.totalOrdersToday).toBe(2);
     expect(result.totalRevenueToday).toBe(100);
+    expect(transactionsRepository.sumPaymentsByDateRange).toHaveBeenCalled();
   });
 });

--- a/src/modules/orders/useCases/getAdminHomeDashboard/GetAdminHomeDashboardUseCase.ts
+++ b/src/modules/orders/useCases/getAdminHomeDashboard/GetAdminHomeDashboardUseCase.ts
@@ -1,7 +1,11 @@
+import dayjs from "@config/dayjs.config";
 import { IOrdersRepository } from "@modules/orders/repositories/IOrdersRepository";
 import { OrderProps } from "@modules/orders/types";
 import { IStockRepository } from "@modules/stock/repositories/IStockRepository";
+import { ITransactionsRepository } from "@modules/transactions/repositories/ITransactionsRepository";
 import { inject, injectable } from "tsyringe";
+
+const BUSINESS_TIMEZONE = "America/Recife";
 
 export type AdminHomeDashboardData = {
   totalOrdersToday: number;
@@ -18,12 +22,31 @@ export class GetAdminHomeDashboardUseCase {
     @inject("OrdersRepository")
     private ordersRepository: IOrdersRepository,
     @inject("StockRepository")
-    private stockRepository: IStockRepository
+    private stockRepository: IStockRepository,
+    @inject("TransactionsRepository")
+    private transactionsRepository: ITransactionsRepository
   ) {}
 
   async execute(): Promise<AdminHomeDashboardData> {
-    const todayOrders = await this.ordersRepository.findByDay(new Date());
-    const stockItems = await this.stockRepository.findAll();
+    const todayInBusinessTimezone = dayjs().tz(BUSINESS_TIMEZONE);
+    const startOfToday = todayInBusinessTimezone
+      .clone()
+      .startOf("day")
+      .toDate();
+    const endOfTodayExclusive = todayInBusinessTimezone
+      .clone()
+      .endOf("day")
+      .add(1, "millisecond")
+      .toDate();
+
+    const [todayOrders, stockItems, totalRevenueToday] = await Promise.all([
+      this.ordersRepository.findByDay(new Date()),
+      this.stockRepository.findAll(),
+      this.transactionsRepository.sumPaymentsByDateRange(
+        startOfToday,
+        endOfTodayExclusive
+      ),
+    ]);
 
     const waterStockItem = stockItems.find((item) => item.type === "WATER");
     const gasStockItem = stockItems.find((item) => item.type === "GAS");
@@ -34,17 +57,8 @@ export class GetAdminHomeDashboardUseCase {
       gasOrdersToday: this.countOrdersByProductType(todayOrders, "GAS"),
       waterStockQuantity: waterStockItem?.quantity ?? 0,
       gasStockQuantity: gasStockItem?.quantity ?? 0,
-      totalRevenueToday: this.calculatePaidRevenueToday(todayOrders),
+      totalRevenueToday,
     };
-  }
-
-  private calculatePaidRevenueToday(orders: OrderProps[]): number {
-    return orders
-      .filter((order) => order.payment_state === "PAGO")
-      .reduce(
-        (accumulatedTotal, order) => accumulatedTotal + Number(order.total),
-        0
-      );
   }
 
   private countOrdersByProductType(

--- a/src/shared/infra/http/routes/transactions.routes.ts
+++ b/src/shared/infra/http/routes/transactions.routes.ts
@@ -14,7 +14,12 @@ const findTransactionByIdController = new FindTransactionByIdController();
 const findTransactionsByOrderIdController =
   new FindTransactionsByOrderIdController();
 
-transactionsRoutes.post("/", ensureAdmin, paymentController.handle);
+transactionsRoutes.post(
+  "/",
+  ensureAuthenticated,
+  ensureAdmin,
+  paymentController.handle
+);
 
 transactionsRoutes.get(
   "/:id",


### PR DESCRIPTION
## Summary
- Total apurado do Início passa a somar transactions `PAYMENT` do dia (America/Recife), em vez de `order.total` (zerado ao marcar como Pago).
- Faturamento (Gestão) usa o mesmo fuso de Recife no intervalo de datas, para pagamentos noturnos entrarem no dia correto.
- POST de pagamento exige `ensureAuthenticated` antes de `ensureAdmin`.

## Test plan
- [ ] Marcar pedido como Pago no detalhe e conferir Início → Total apurado
- [ ] Conferir Gestão → Faturamento (Hoje), inclusive após 21h
- [ ] Registrar pagamento parcial e validar que o valor pago entra no recebido
- [ ] Confirmar que pedido só PENDENTE/VENCIDO continua em “Em aberto”