### PR TITLE
fix: entrega config de monitoramento na VPS e emite log JSON no stdout

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -40,7 +40,20 @@ jobs:
           # Sync docker-compose files
           scp -i ~/.ssh/id_rsa -o StrictHostKeyChecking=no \
             docker-compose.dev.yml \
+            docker-compose.monitoring-dev.yml \
             ${{ secrets.VPS_USER }}@${{ secrets.VPS_HOST }}:/home/deploy/gas-e-agua-backend/
+
+          # Sync monitoring configs (Promtail/Loki/Grafana leem esses arquivos por bind mount)
+          ssh -i ~/.ssh/id_rsa -o StrictHostKeyChecking=no ${{ secrets.VPS_USER }}@${{ secrets.VPS_HOST }} \
+            "mkdir -p /home/deploy/gas-e-agua-backend/monitoring"
+
+          scp -i ~/.ssh/id_rsa -o StrictHostKeyChecking=no -r \
+            monitoring/alertmanager \
+            monitoring/grafana \
+            monitoring/loki \
+            monitoring/prometheus \
+            monitoring/promtail \
+            ${{ secrets.VPS_USER }}@${{ secrets.VPS_HOST }}:/home/deploy/gas-e-agua-backend/monitoring/
 
           # Sync essential scripts
           scp -i ~/.ssh/id_rsa -o StrictHostKeyChecking=no \
@@ -105,6 +118,7 @@ jobs:
               "MYSQL_USER=gas_e_agua_dev" \
               "MYSQL_PASSWORD=$MYSQL_PASSWORD_DEV" \
               "NODE_ENV=development" \
+              "LOG_FORMAT=json" \
               "PORT=3333" \
               "JWT_SECRET=$JWT_SECRET_DEV" \
               "JWT_REFRESH_SECRET=$JWT_REFRESH_SECRET_DEV" \

--- a/.github/workflows/deploy-prd.yml
+++ b/.github/workflows/deploy-prd.yml
@@ -43,6 +43,18 @@ jobs:
             docker-compose.monitoring-prd.yml \
             ${{ secrets.VPS_USER }}@${{ secrets.VPS_HOST }}:/home/deploy/gas-e-agua-backend/
 
+          # Sync monitoring configs (Promtail/Loki/Grafana leem esses arquivos por bind mount)
+          ssh -i ~/.ssh/id_rsa -o StrictHostKeyChecking=no ${{ secrets.VPS_USER }}@${{ secrets.VPS_HOST }} \
+            "mkdir -p /home/deploy/gas-e-agua-backend/monitoring"
+
+          scp -i ~/.ssh/id_rsa -o StrictHostKeyChecking=no -r \
+            monitoring/alertmanager \
+            monitoring/grafana \
+            monitoring/loki \
+            monitoring/prometheus \
+            monitoring/promtail \
+            ${{ secrets.VPS_USER }}@${{ secrets.VPS_HOST }}:/home/deploy/gas-e-agua-backend/monitoring/
+
           # Sync essential scripts
           scp -i ~/.ssh/id_rsa -o StrictHostKeyChecking=no \
             scripts/deploy/deploy.sh \
@@ -106,6 +118,7 @@ jobs:
               "MYSQL_USER=gas_e_agua" \
               "MYSQL_PASSWORD=$MYSQL_PASSWORD_PRD" \
               "NODE_ENV=production" \
+              "LOG_FORMAT=json" \
               "PORT=3333" \
               "JWT_SECRET=$JWT_SECRET_PRD" \
               "JWT_REFRESH_SECRET=$JWT_REFRESH_SECRET_PRD" \

--- a/docker-compose.app.yml
+++ b/docker-compose.app.yml
@@ -44,6 +44,11 @@ services:
       REDIS_URL: ${REDIS_URL:-redis://redis:6379}
     volumes:
       - ./logs:/app/logs
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "3"
     networks:
       - app-network
     depends_on:

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -44,6 +44,11 @@ services:
       REDIS_URL: ${REDIS_URL:-redis://redis:6379}
     volumes:
       - ./logs-dev:/app/logs
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "3"
     networks:
       - app-network-dev
     depends_on:

--- a/docs/development/setup.md
+++ b/docs/development/setup.md
@@ -64,6 +64,11 @@ NODE_ENV=development
 PORT=3333
 JWT_SECRET=jwt_secret_dev
 
+# Logs (opcional)
+# Deixe em branco para log colorido no terminal.
+# LOG_FORMAT=json emite JSON no console — é o que a VPS usa para o Promtail coletar.
+LOG_FORMAT=
+
 # Redis (rate limiting)
 REDIS_HOST=redis
 REDIS_PORT=6379

--- a/env.app.prd.example
+++ b/env.app.prd.example
@@ -24,6 +24,12 @@ MYSQL_PASSWORD=CHANGE_THIS_STRONG_PASSWORD_456!
 NODE_ENV=production
 PORT=3333
 
+# Logs
+# --------------------------------------------------
+# LOG_FORMAT=json faz o console emitir JSON (formato que o Promtail coleta)
+# Sem a variável, o log sai colorido e legível para leitura manual
+LOG_FORMAT=json
+
 # Timeouts (em millisegundos)
 # --------------------------------------------------
 # REQUEST_TIMEOUT: Tempo máximo para completar uma requisição HTTP

--- a/env.docker.example
+++ b/env.docker.example
@@ -10,6 +10,11 @@ PORT=3333
 REQUEST_TIMEOUT=30000
 DATABASE_QUERY_TIMEOUT=15000
 
+# Logs
+# LOG_FORMAT=json faz o console emitir JSON (formato que o Promtail coleta)
+# Sem a variável, o log local sai colorido e legível
+LOG_FORMAT=json
+
 # JWT Configuration (REQUIRED)
 JWT_SECRET=change_this_to_strong_random_secret_min_32_chars
 JWT_REFRESH_SECRET=change_this_to_another_strong_random_secret

--- a/monitoring/promtail/promtail-config.yml
+++ b/monitoring/promtail/promtail-config.yml
@@ -9,28 +9,7 @@ clients:
   - url: http://loki:3100/loki/api/v1/push
 
 scrape_configs:
-  # Winston JSON (combined.log já inclui error; não raspar error.log para evitar duplicata)
-  - job_name: gas-e-agua-app-files
-    static_configs:
-      - targets:
-          - localhost
-        labels:
-          job: gas-e-agua-backend
-          __path__: /var/log/app/combined.log
-    pipeline_stages:
-      - json:
-          expressions:
-            level: level
-            type: type
-            timestamp: timestamp
-      - timestamp:
-          source: timestamp
-          format: RFC3339
-      - labels:
-          level:
-          type:
-
-  # Stdout do container da API (crash/npm). Job separado para não duplicar no Grafana.
+  # Stdout do container da API (JSON do Winston quando LOG_FORMAT=json)
   - job_name: docker
     docker_sd_configs:
       - host: unix:///var/run/docker.sock
@@ -48,9 +27,16 @@ scrape_configs:
       - source_labels: ["__meta_docker_container_name"]
         regex: "/gas-e-agua-app.*"
         target_label: "job"
-        replacement: "gas-e-agua-backend-stdout"
+        replacement: "gas-e-agua-backend"
     pipeline_stages:
+      # Linhas não-JSON (morgan) seguem sem level/type, mas continuam ingeridas
+      - json:
+          expressions:
+            level: level
+            type: type
       - labels:
           container_name:
           stream:
           job:
+          level:
+          type:

--- a/monitoring/promtail/promtail-config.yml
+++ b/monitoring/promtail/promtail-config.yml
@@ -34,9 +34,7 @@ scrape_configs:
           expressions:
             level: level
             type: type
+      # container_name, stream e job já viram labels via relabel_configs
       - labels:
-          container_name:
-          stream:
-          job:
           level:
           type:

--- a/scripts/deploy/deploy.sh
+++ b/scripts/deploy/deploy.sh
@@ -293,6 +293,10 @@ log_group_end
 log_group_start "📊 Starting monitoring stack"
 log_info "Compose file: $MONITORING_FILE"
 docker compose -p "$PROJECT" -f "$MONITORING_FILE" up -d
+
+# Promtail lê a config por bind mount: sem recriar, mudanças no YAML não são aplicadas
+log_info "Recreating promtail to apply config changes..."
+docker compose -p "$PROJECT" -f "$MONITORING_FILE" up -d --force-recreate promtail
 log_success "Monitoring stack started"
 log_group_end
 

--- a/src/shared/services/LoggerService.ts
+++ b/src/shared/services/LoggerService.ts
@@ -64,16 +64,21 @@ const logger = winston.createLogger({
   ],
 });
 
-if (process.env.NODE_ENV !== "production") {
-  logger.add(
-    new winston.transports.Console({
-      format: winston.format.combine(
-        winston.format.colorize(),
-        winston.format.simple()
-      ),
-    })
-  );
+// Sem format próprio, o Console reaproveita o JSON do logger (formato lido pelo Promtail)
+function createConsoleTransport() {
+  if (process.env.LOG_FORMAT === "json") {
+    return new winston.transports.Console();
+  }
+
+  return new winston.transports.Console({
+    format: winston.format.combine(
+      winston.format.colorize(),
+      winston.format.simple()
+    ),
+  });
 }
+
+logger.add(createConsoleTransport());
 
 export class LoggerService {
   static info(message: string, meta?: Record<string, unknown>): void {


### PR DESCRIPTION
## Contexto

Um erro em DEV não apareceu no Grafana mesmo após o #74. A causa é anterior à config do Promtail: **o deploy nunca sincronizou a pasta `monitoring/`**, então qualquer alteração naqueles YAMLs ficava só no Git e a VPS seguia com a config antiga.

## Summary

- Workflows de DEV e PRD passam a sincronizar `monitoring/` (e o `docker-compose.monitoring-dev.yml`, que só o PRD enviava).
- `deploy.sh` recria o Promtail após subir o stack — como a config é bind mount, `up -d` sozinho não a reaplica.
- Promtail passa a usar o stdout do container como fonte única, com `job=gas-e-agua-backend` e labels `level`/`type`, que é o que os painéis do dashboard consultam.
- Winston emite JSON no console quando `LOG_FORMAT=json` (definido apenas no `.env` gerado na VPS); no desenvolvimento local o log segue colorido.
- Log driver do Docker limitado a `max-size: 10m` / `max-file: 3` no serviço `app`, já que agora todo o log da aplicação passa pelo stdout.

Removido o scrape de arquivo introduzido no #74: ele dependia de `logs-dev` ser gravável pelo uid 1001 do container e quebraria na rotação do Winston, quando o arquivo ativo passa a ser `combined1.log`.

## Validação local

Config validada com `promtail -check-syntax` e o pipeline verificado com `promtail -dry-run` contra o socket do Docker, usando um container de teste. Labels produzidos:

```
{container_name="gas-e-agua-app-labeltest", job="gas-e-agua-backend", level="error", stream="stdout", type="application_error"}
```

Isso cobre a query do painel de erros: `{job="gas-e-agua-backend"} | json | level = "error"`.

## Ressalva conhecida

`promtail-dev` e `promtail-prd` montam o mesmo socket do Docker do host, então cada um enxerga o container do outro ambiente sob o mesmo `job`. Comportamento pré-existente; dá para distinguir pelo label `container_name`.

## Test plan

- [ ] Após o merge, acompanhar o deploy de DEV e confirmar que `monitoring/promtail/promtail-config.yml` chegou na VPS
- [ ] `docker exec promtail-dev cat /etc/promtail/config.yml` reflete a versão nova
- [ ] `docker logs gas-e-agua-app-dev --tail 5` mostra JSON sem códigos de cor
- [ ] Provocar um erro na API e conferir o painel "Logs de Erro" no Grafana