### PR TITLE
feat: publica política de privacidade em GET /privacidade

### DIFF
--- a/src/modules/legal/accountDeletionHtml.ts
+++ b/src/modules/legal/accountDeletionHtml.ts
@@ -1,0 +1,49 @@
+import {
+  PRIVACY_POLICY_CONTACT_EMAIL,
+  PRIVACY_POLICY_CONTACT_PHONE_DISPLAY,
+  PRIVACY_POLICY_CONTACT_WHATSAPP_URL,
+} from "./privacyPolicyHtml";
+
+const ACCOUNT_DELETION_REQUEST_MESSAGE =
+  "Quero solicitar a exclusão da minha conta e dos meus dados no aplicativo Eduardo Gás.";
+
+export function buildAccountDeletionHtml(): string {
+  const whatsAppRequestUrl = `${PRIVACY_POLICY_CONTACT_WHATSAPP_URL}?text=${encodeURIComponent(
+    ACCOUNT_DELETION_REQUEST_MESSAGE
+  )}`;
+  const emailSubject = encodeURIComponent(
+    "Solicitação de exclusão de conta e dados"
+  );
+  const emailBody = encodeURIComponent(
+    `${ACCOUNT_DELETION_REQUEST_MESSAGE}\n\nNome:\nE-mail da conta:\nTelefone:\n`
+  );
+  const emailRequestUrl = `mailto:${PRIVACY_POLICY_CONTACT_EMAIL}?subject=${emailSubject}&amp;body=${emailBody}`;
+
+  return `<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Solicitar exclusão da conta e dos dados — Eduardo Gás</title>
+  <style>
+    body { font-family: system-ui, sans-serif; max-width: 42rem; margin: 2rem auto; padding: 0 1rem; line-height: 1.6; color: #1a1a1a; }
+    h1 { font-size: 1.75rem; }
+    h2 { font-size: 1.15rem; margin-top: 1.75rem; }
+  </style>
+</head>
+<body>
+  <h1>Solicitar exclusão da conta e dos dados</h1>
+  <p>Use um dos contatos abaixo para pedir a exclusão da sua conta e dos seus dados no aplicativo Eduardo Gás. Informe o nome, o e-mail e o telefone cadastrados.</p>
+
+  <h2>Como solicitar</h2>
+  <p><a href="${whatsAppRequestUrl}">WhatsApp ${PRIVACY_POLICY_CONTACT_PHONE_DISPLAY}</a></p>
+  <p><a href="${emailRequestUrl}">E-mail ${PRIVACY_POLICY_CONTACT_EMAIL}</a></p>
+
+  <h2>O que é excluído</h2>
+  <p>Conta (nome, e-mail, telefone e senha), endereços de entrega e token de notificação do aparelho.</p>
+
+  <h2>O que pode ser mantido</h2>
+  <p>Registros de pedidos e pagamentos pelo tempo necessário para cumprir obrigações legais. Não vendemos dados.</p>
+</body>
+</html>`;
+}

--- a/src/modules/legal/privacyPolicyHtml.ts
+++ b/src/modules/legal/privacyPolicyHtml.ts
@@ -1,0 +1,53 @@
+export const PRIVACY_POLICY_CONTACT_EMAIL = "eduardogas2013@hotmail.com";
+export const PRIVACY_POLICY_CONTACT_PHONE_DISPLAY = "(81) 99732-67792";
+export const PRIVACY_POLICY_LAST_UPDATED_LABEL = "28 de agosto de 2026";
+export const PRIVACY_POLICY_ANDROID_PACKAGE_NAME = "com.gaseagua.app";
+
+export function buildPrivacyPolicyHtml(): string {
+  return `<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Política de Privacidade — Eduardo Gás</title>
+  <style>
+    body { font-family: system-ui, sans-serif; max-width: 42rem; margin: 2rem auto; padding: 0 1rem; line-height: 1.6; color: #1a1a1a; }
+    h1 { font-size: 1.75rem; }
+    h2 { font-size: 1.15rem; margin-top: 1.75rem; }
+  </style>
+</head>
+<body>
+  <h1>Política de Privacidade — Eduardo Gás</h1>
+  <p>Última atualização: ${PRIVACY_POLICY_LAST_UPDATED_LABEL}.</p>
+  <p>O aplicativo Eduardo Gás (pacote ${PRIVACY_POLICY_ANDROID_PACKAGE_NAME}) é usado para pedidos de gás e água. Esta política descreve quais dados tratamos e para quê, nos termos da LGPD (Lei nº 13.709/2018).</p>
+
+  <h2>1. Quem é o responsável</h2>
+  <p>Eduardo Gás. Contato: WhatsApp/telefone ${PRIVACY_POLICY_CONTACT_PHONE_DISPLAY}. E-mail: <a href="mailto:${PRIVACY_POLICY_CONTACT_EMAIL}">${PRIVACY_POLICY_CONTACT_EMAIL}</a>.</p>
+
+  <h2>2. Quais dados coletamos</h2>
+  <p>Cadastro: nome, e-mail, telefone e senha.</p>
+  <p>Endereço de entrega (local, rua, número, referência).</p>
+  <p>Pedidos (produtos, quantidades, status) e forma de pagamento informada (Pix, dinheiro ou cartão) — esse campo é opcional.</p>
+  <p>Token de notificação do aparelho (FCM), para avisos de pedido e mensagens do administrador.</p>
+  <p>Não pedimos data de nascimento. Não vendemos dados.</p>
+
+  <h2>3. Para que usamos</h2>
+  <p>Criar e autenticar a conta, entregar pedidos, registrar pagamentos, enviar notificações e melhorar o atendimento.</p>
+
+  <h2>4. Com quem compartilhamos</h2>
+  <p>Só com serviços necessários ao app: hospedagem da API, Google Play e Firebase Cloud Messaging. Não compartilhamos com anunciantes.</p>
+
+  <h2>5. Por quanto tempo</h2>
+  <p>Enquanto a conta existir e pelo tempo necessário para cumprir obrigações legais. Você pode pedir exclusão da conta e dos dados pelo contato acima.</p>
+
+  <h2>6. Seus direitos (LGPD)</h2>
+  <p>Acessar, corrigir, atualizar ou pedir exclusão dos dados, além de informações sobre o tratamento. Fale conosco pelo telefone ou e-mail acima.</p>
+
+  <h2>7. Segurança</h2>
+  <p>Senha é armazenada de forma protegida. Comunicação com o servidor em produção usa HTTPS.</p>
+
+  <h2>8. Alterações</h2>
+  <p>Se esta política mudar, atualizaremos esta página e a data acima.</p>
+</body>
+</html>`;
+}

--- a/src/modules/legal/privacyPolicyHtml.ts
+++ b/src/modules/legal/privacyPolicyHtml.ts
@@ -1,7 +1,10 @@
 export const PRIVACY_POLICY_CONTACT_EMAIL = "eduardogas2013@hotmail.com";
 export const PRIVACY_POLICY_CONTACT_PHONE_DISPLAY = "(81) 99732-67792";
+export const PRIVACY_POLICY_CONTACT_WHATSAPP_URL =
+  "https://wa.me/55819973267792";
 export const PRIVACY_POLICY_LAST_UPDATED_LABEL = "28 de agosto de 2026";
 export const PRIVACY_POLICY_ANDROID_PACKAGE_NAME = "com.gaseagua.app";
+export const ACCOUNT_DELETION_REQUEST_PATH = "/exclusao-de-conta";
 
 export function buildPrivacyPolicyHtml(): string {
   return `<!DOCTYPE html>
@@ -38,7 +41,7 @@ export function buildPrivacyPolicyHtml(): string {
   <p>Só com serviços necessários ao app: hospedagem da API, Google Play e Firebase Cloud Messaging. Não compartilhamos com anunciantes.</p>
 
   <h2>5. Por quanto tempo</h2>
-  <p>Enquanto a conta existir e pelo tempo necessário para cumprir obrigações legais. Você pode pedir exclusão da conta e dos dados pelo contato acima.</p>
+  <p>Enquanto a conta existir e pelo tempo necessário para cumprir obrigações legais. Você pode pedir exclusão da conta e dos dados em <a href="${ACCOUNT_DELETION_REQUEST_PATH}">solicitar exclusão da conta e dos dados</a>.</p>
 
   <h2>6. Seus direitos (LGPD)</h2>
   <p>Acessar, corrigir, atualizar ou pedir exclusão dos dados, além de informações sobre o tratamento. Fale conosco pelo telefone ou e-mail acima.</p>

--- a/src/modules/legal/useCases/getAccountDeletion/GetAccountDeletionController.test.ts
+++ b/src/modules/legal/useCases/getAccountDeletion/GetAccountDeletionController.test.ts
@@ -1,0 +1,21 @@
+import {
+  PRIVACY_POLICY_CONTACT_EMAIL,
+  PRIVACY_POLICY_CONTACT_PHONE_DISPLAY,
+  PRIVACY_POLICY_CONTACT_WHATSAPP_URL,
+} from "@modules/legal/privacyPolicyHtml";
+import request from "supertest";
+
+import { app } from "@shared/infra/http/app";
+
+describe("GetAccountDeletionController", () => {
+  it("should return the account deletion request html without authentication", async () => {
+    const response = await request(app).get("/exclusao-de-conta");
+
+    expect(response.status).toBe(200);
+    expect(response.headers["content-type"]).toMatch(/text\/html/);
+    expect(response.text).toContain("Solicitar exclusão da conta e dos dados");
+    expect(response.text).toContain(PRIVACY_POLICY_CONTACT_EMAIL);
+    expect(response.text).toContain(PRIVACY_POLICY_CONTACT_PHONE_DISPLAY);
+    expect(response.text).toContain(PRIVACY_POLICY_CONTACT_WHATSAPP_URL);
+  });
+});

--- a/src/modules/legal/useCases/getAccountDeletion/GetAccountDeletionController.ts
+++ b/src/modules/legal/useCases/getAccountDeletion/GetAccountDeletionController.ts
@@ -1,0 +1,13 @@
+import { Request, Response } from "express";
+
+import { buildAccountDeletionHtml } from "../../accountDeletionHtml";
+
+export class GetAccountDeletionController {
+  async handle(_: Request, response: Response): Promise<Response> {
+    const accountDeletionHtml = buildAccountDeletionHtml();
+
+    response.set("Content-Type", "text/html; charset=utf-8");
+
+    return response.status(200).send(accountDeletionHtml);
+  }
+}

--- a/src/modules/legal/useCases/getPrivacyPolicy/GetPrivacyPolicyController.test.ts
+++ b/src/modules/legal/useCases/getPrivacyPolicy/GetPrivacyPolicyController.test.ts
@@ -1,10 +1,10 @@
-import request from "supertest";
-
 import {
   PRIVACY_POLICY_ANDROID_PACKAGE_NAME,
   PRIVACY_POLICY_CONTACT_EMAIL,
   PRIVACY_POLICY_CONTACT_PHONE_DISPLAY,
 } from "@modules/legal/privacyPolicyHtml";
+import request from "supertest";
+
 import { app } from "@shared/infra/http/app";
 
 describe("GetPrivacyPolicyController", () => {
@@ -18,5 +18,6 @@ describe("GetPrivacyPolicyController", () => {
     expect(response.text).toContain(PRIVACY_POLICY_CONTACT_PHONE_DISPLAY);
     expect(response.text).toContain(PRIVACY_POLICY_ANDROID_PACKAGE_NAME);
     expect(response.text).toContain("LGPD");
+    expect(response.text).toContain('href="/exclusao-de-conta"');
   });
 });

--- a/src/modules/legal/useCases/getPrivacyPolicy/GetPrivacyPolicyController.test.ts
+++ b/src/modules/legal/useCases/getPrivacyPolicy/GetPrivacyPolicyController.test.ts
@@ -1,0 +1,22 @@
+import request from "supertest";
+
+import {
+  PRIVACY_POLICY_ANDROID_PACKAGE_NAME,
+  PRIVACY_POLICY_CONTACT_EMAIL,
+  PRIVACY_POLICY_CONTACT_PHONE_DISPLAY,
+} from "@modules/legal/privacyPolicyHtml";
+import { app } from "@shared/infra/http/app";
+
+describe("GetPrivacyPolicyController", () => {
+  it("should return the privacy policy html without authentication", async () => {
+    const response = await request(app).get("/privacidade");
+
+    expect(response.status).toBe(200);
+    expect(response.headers["content-type"]).toMatch(/text\/html/);
+    expect(response.text).toContain("Política de Privacidade — Eduardo Gás");
+    expect(response.text).toContain(PRIVACY_POLICY_CONTACT_EMAIL);
+    expect(response.text).toContain(PRIVACY_POLICY_CONTACT_PHONE_DISPLAY);
+    expect(response.text).toContain(PRIVACY_POLICY_ANDROID_PACKAGE_NAME);
+    expect(response.text).toContain("LGPD");
+  });
+});

--- a/src/modules/legal/useCases/getPrivacyPolicy/GetPrivacyPolicyController.ts
+++ b/src/modules/legal/useCases/getPrivacyPolicy/GetPrivacyPolicyController.ts
@@ -1,0 +1,13 @@
+import { Request, Response } from "express";
+
+import { buildPrivacyPolicyHtml } from "../../privacyPolicyHtml";
+
+export class GetPrivacyPolicyController {
+  async handle(_: Request, response: Response): Promise<Response> {
+    const privacyPolicyHtml = buildPrivacyPolicyHtml();
+
+    response.set("Content-Type", "text/html; charset=utf-8");
+
+    return response.status(200).send(privacyPolicyHtml);
+  }
+}

--- a/src/shared/infra/http/routes/index.ts
+++ b/src/shared/infra/http/routes/index.ts
@@ -2,6 +2,7 @@ import { Router } from "express";
 
 import { addonsRoutes } from "./addons.routes";
 import { authenticateRoutes } from "./authenticate.routes";
+import { legalRoutes } from "./legal.routes";
 import { metricsRoutes } from "./metrics.routes";
 import { notificationsRoutes } from "./notifications.routes";
 import { orderRoutes } from "./orders.routes";
@@ -13,6 +14,7 @@ import { usersRoutes } from "./users.routes";
 const router = Router();
 
 router.use(authenticateRoutes);
+router.use(legalRoutes);
 router.use("/users", usersRoutes);
 router.use("/orders", orderRoutes);
 router.use("/stock", stockRoutes);

--- a/src/shared/infra/http/routes/legal.routes.ts
+++ b/src/shared/infra/http/routes/legal.routes.ts
@@ -1,0 +1,8 @@
+import { GetPrivacyPolicyController } from "@modules/legal/useCases/getPrivacyPolicy/GetPrivacyPolicyController";
+import { Router } from "express";
+
+export const legalRoutes = Router();
+
+const getPrivacyPolicyController = new GetPrivacyPolicyController();
+
+legalRoutes.get("/privacidade", getPrivacyPolicyController.handle);

--- a/src/shared/infra/http/routes/legal.routes.ts
+++ b/src/shared/infra/http/routes/legal.routes.ts
@@ -1,8 +1,11 @@
+import { GetAccountDeletionController } from "@modules/legal/useCases/getAccountDeletion/GetAccountDeletionController";
 import { GetPrivacyPolicyController } from "@modules/legal/useCases/getPrivacyPolicy/GetPrivacyPolicyController";
 import { Router } from "express";
 
 export const legalRoutes = Router();
 
 const getPrivacyPolicyController = new GetPrivacyPolicyController();
+const getAccountDeletionController = new GetAccountDeletionController();
 
 legalRoutes.get("/privacidade", getPrivacyPolicyController.handle);
+legalRoutes.get("/exclusao-de-conta", getAccountDeletionController.handle);

--- a/swagger.json
+++ b/swagger.json
@@ -71,6 +71,24 @@
         }
       }
     },
+    "/privacidade": {
+      "get": {
+        "summary": "Retorna a política de privacidade",
+        "tags": ["Legal"],
+        "responses": {
+          "200": {
+            "description": "Página HTML da política de privacidade",
+            "content": {
+              "text/html": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/users": {
       "post": {
         "summary": "Cria um novo usuário",

--- a/swagger.json
+++ b/swagger.json
@@ -89,6 +89,24 @@
         }
       }
     },
+    "/exclusao-de-conta": {
+      "get": {
+        "summary": "Retorna a página para solicitar exclusão da conta e dos dados",
+        "tags": ["Legal"],
+        "responses": {
+          "200": {
+            "description": "Página HTML com os contatos para pedir exclusão da conta",
+            "content": {
+              "text/html": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/users": {
       "post": {
         "summary": "Cria um novo usuário",


### PR DESCRIPTION
## Summary
- Expõe `GET /privacidade` sem autenticação, com a política em HTML para o Play Console.
- Contato: telefone do app e e-mail do admin da seed (`eduardogas2013@hotmail.com`).
- URL temporária após o deploy de develop: `https://api-dev.gas-e-agua.space/privacidade`.

## Test plan
- [ ] `GET /privacidade` retorna 200 e `text/html` sem token.
- [ ] A página mostra telefone `(81) 99732-67792` e e-mail `eduardogas2013@hotmail.com`.
- [ ] Abrir a URL no browser após o deploy de develop e colar no Play Console.